### PR TITLE
Upgrade library and do some refactor inside Program/DirectoryServer

### DIFF
--- a/Irc.Extensions.Apollo.Directory/DirectoryServer.cs
+++ b/Irc.Extensions.Apollo.Directory/DirectoryServer.cs
@@ -24,13 +24,23 @@ public class DirectoryServer : ApolloServer
     public DirectoryServer(ISocketServer socketServer, ISecurityManager securityManager,
         IFloodProtectionManager floodProtectionManager, IDataStore dataStore, IList<IChannel> channels,
         ICommandCollection commands, IUserFactory userFactory = null,
-        ICredentialProvider? ntlmCredentialProvider = null)
+        ICredentialProvider? ntlmCredentialProvider = null, string? chatServerIp = null)
         : base(socketServer, securityManager,
             floodProtectionManager, dataStore, channels, commands, userFactory ?? new ApolloUserFactory(),
             ntlmCredentialProvider)
     {
         DisableGuestMode = true;
         DisableUserRegistration = true;
+
+        if (!string.IsNullOrEmpty(chatServerIp))
+        {
+            var parts = chatServerIp.Split(':');
+            if (parts.Length > 0)
+                ChatServerIP = parts[0];
+            if (parts.Length > 1)
+                ChatServerPORT = parts[1];
+        }
+
         FlushCommands();
         AddCommand(new Ircvers());
         AddCommand(new Auth());

--- a/Irc7d/Irc7d.csproj
+++ b/Irc7d/Irc7d.csproj
@@ -13,9 +13,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Irc.Extensions.Apollo.Directory\Irc.Extensions.Apollo.Directory.csproj" />
@@ -26,6 +23,7 @@
 
   <ItemGroup>
     <None Remove="states\" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <None Update="DefaultCredentials.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Irc7d/ServerOptions.cs
+++ b/Irc7d/ServerOptions.cs
@@ -1,0 +1,16 @@
+﻿using System.CommandLine;
+
+namespace Irc7d;
+
+public class ServerOptions
+{
+    public string? ConfigPath { get; set; }
+    public string? BindIp { get; set; }
+    public int BindPort { get; set; }
+    public int Backlog { get; set; }
+    public int BufferSize { get; set; }
+    public int MaxConnections { get; set; }
+    public string? Fqdn { get; set; }
+    public string? ServerType { get; set; }
+    public string? ChatServerIp { get; set; }
+}


### PR DESCRIPTION
- Move the logic of setting the ChatServerIP and PORT into the DirectoryServer, instead of the Main()
- Refactor the Main() to be more readable, split the logic
- Move from Microsoft.Extensions.CommandLineUtils (deprecated), to System.CommandLine
- Doing some clean-up also inside Irc7d/Program.cs, Irc.Extensions.Apollo.Directory/DirectoryServer.cs