### PR TITLE
Patch(Command): Create

### DIFF
--- a/Irc.Extensions.Apollo.Directory/Commands/Create.cs
+++ b/Irc.Extensions.Apollo.Directory/Commands/Create.cs
@@ -6,9 +6,12 @@ namespace Irc.Extensions.Apollo.Directory.Commands;
 
 internal class Create : Command, ICommand
 {
-    public Create()
+    private bool _isAds;
+
+    public Create(bool isAds = false)
     {
         _requiredMinimumParameters = 1;
+        _isAds = isAds;
     }
 
     public EnumCommandDataType GetDataType()
@@ -18,6 +21,12 @@ internal class Create : Command, ICommand
 
     public void Execute(IChatFrame chatFrame)
     {
-        chatFrame.User.Send(Raw.IRCX_RPL_FINDS_613(chatFrame.Server, chatFrame.User));
+        var messageToSend = Raw.IRCX_RPL_FINDS_613(chatFrame.Server, chatFrame.User);
+        if (_isAds)
+        {
+            messageToSend = ApolloDirectoryRaws.RPL_FINDS_MSN((DirectoryServer)chatFrame.Server, chatFrame.User);
+        }
+
+        chatFrame.User.Send(messageToSend);
     }
 }

--- a/Irc.Extensions.Apollo.Directory/DirectoryServer.cs
+++ b/Irc.Extensions.Apollo.Directory/DirectoryServer.cs
@@ -50,7 +50,7 @@ public class DirectoryServer : ApolloServer
         AddCommand(new UserCommand(), EnumProtocolType.IRC, "User");
         AddCommand(new Finds());
         AddCommand(new Prop());
-        AddCommand(new Create());
+        AddCommand(new Create(true));
         AddCommand(new Ping());
         AddCommand(new Pong());
         AddCommand(new Version());

--- a/Irc7d/Program.cs
+++ b/Irc7d/Program.cs
@@ -90,6 +90,7 @@ internal class Program
         var fqdnOption = new Option<string>(["-f", "--fqdn"], "The FQDN of the machine (default localhost)") { ArgumentHelpName = "fqdn" };
         fqdnOption.SetDefaultValue("localhost");
         var serverTypeOption = new Option<string>(["-t", "--type"], "Type of server e.g. IRC, IRCX, ACS, ADS") { ArgumentHelpName = "type" };
+        serverTypeOption.SetDefaultValue("ACS");
         var chatServerIpOption = new Option<string>(["-s", "--server"], "The Chat Server Ip and Port e.g. 127.0.0.1:6667") { ArgumentHelpName = "server" };
 
         var options = new Dictionary<string, Option>


### PR DESCRIPTION
- Patching the Create command to allow to work (response in that case) also from the ADS, with the right data, like the Finds command.
- Add a fallback value for the ServerType option, for the moment in ACS mode.