### PR TITLE
OOM via unbounded accumulated buffer in SocketConnection

### DIFF
--- a/Irc.Daemon/SocketConnection.cs
+++ b/Irc.Daemon/SocketConnection.cs
@@ -129,6 +129,12 @@ public class SocketConnection : IConnection
         {
             _received = $"{_received}{data}";
 
+            if (_received.Length > 1024)
+            {
+                Disconnect("Line too long");
+                return;
+            }
+
             var bNewLinePending = !_received.EndsWith('\r') && !_received.EndsWith('\n');
 
             var lines = data.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
For this one, we need to discuss if the 1024 length is the correct one, I picked up the one from the RFC. @jyonxo 