### PR TITLE
Small fix for broken create

### DIFF
--- a/Irc.Directory/Commands/Create.cs
+++ b/Irc.Directory/Commands/Create.cs
@@ -13,16 +13,20 @@ public class Create : Command, ICommand
     public Create()
     {
         // IRC3
-        // CREATE <catcode> <channel> <topic> <mode> <locale> <hostkey> <ownerkey>
+        // CREATE <catcode> <channel> <topic> <mode> [limit] <locale> <hostkey> <ownerkey>
         // IRC4, IRC5
-        //  CREATE <catcode> <channel> <topic> <mode> <locale> <language> <hostkey> <ownerkey>
+        //  CREATE <catcode> <channel> <topic> <mode> [limit] <locale> <language> <hostkey> <ownerkey>
         // IRC7+
-        // CREATE <category> <channel> <topic> <mode> <locale> <language>
+        // CREATE <category> <channel> <topic> <mode> [limit] <locale> <language>
         // <ownerkey> <radio station> [hostkey]
         // The radio station was obsoleted and hence is 0 (assumption)
         
+        // Limit is only considered when 'l' exists in <mode>
+        // Hostkey is optional
+        
         // CREATE CP %#channel %topic ntl 50 EN-US 1 ownerkey 0
-        _requiredMinimumParameters = 9;
+        // CREATE UL %#unknown - - EN-US 1 ownerkey 0
+        _requiredMinimumParameters = 8;
     }
 
     public new EnumCommandDataType GetDataType()


### PR DESCRIPTION
Issue was OCX could not create a channel
```
[2026-03-06T23:52:54Z TRACE msnchat_rs::chat45::sockets::patch] >>> hook_flush_buffer: pending bytes to flush: 71
    CONTENT: "CREATE UL %#The\\bLobby2 - - EN-US 1 DNvzx_CT;[='U-/3JDWh.N(}/n)JSs5 0\r\n"


[2026-03-06T23:52:54Z TRACE msnchat_rs::chat45::sockets::patch] <<< EXIT hook_recv for 0x101714c0, returning 65
    CONTENT: ":DefaultServerName 461 ������4419 Create :Not enough parameters\r\n"
```

- Adjusted `Create` command documentation to reflect optional `[limit……]` parameter.
- Updated `_requiredMinimumParameters` to 8 due to optional hostkey and limit handling logic adjustments.