### PR TITLE
Update error responses for Prop and Access commands

### DIFF
--- a/Irc/Commands/Access.cs
+++ b/Irc/Commands/Access.cs
@@ -41,7 +41,7 @@ internal class Access : Command, ICommand
 
         if (!CanModify(chatFrame, targetObject))
         {
-            chatFrame.User.Send(Raws.IRCX_ERR_SECURITY_908(chatFrame.Server, chatFrame.User));
+            chatFrame.User.Send(Raws.IRCX_ERR_NOACCESS_913(chatFrame.Server, chatFrame.User, targetObject));
             // No permissions
             return;
         }

--- a/Irc/Commands/Prop.cs
+++ b/Irc/Commands/Prop.cs
@@ -116,8 +116,7 @@ public class Prop : Command, ICommand
                             var ircError = prop.EvaluateSet((IChatObject)chatFrame.User, chatObject, propValue);
                             if (ircError == EnumIrcError.ERR_NOPERMS)
                             {
-                                chatFrame.User.Send(Raws.IRCX_ERR_NOACCESS_913(chatFrame.Server, chatFrame.User,
-                                    chatObject));
+                                chatFrame.User.Send(Raws.IRCX_ERR_SECURITY_908(chatFrame.Server, chatFrame.User));
                                 return;
                             }
 
@@ -138,8 +137,7 @@ public class Prop : Command, ICommand
                         }
                         else
                         {
-                            chatFrame.User.Send(Raws.IRCX_ERR_NOACCESS_913(chatFrame.Server, chatFrame.User,
-                                chatObject));
+                            chatFrame.User.Send(Raws.IRCX_ERR_SECURITY_908(chatFrame.Server, chatFrame.User));
                         }
                     }
                     else


### PR DESCRIPTION
- Replace incorrect `IRCX_ERR_NOACCESS_913` with `IRCX_ERR_SECURITY_908` in `Prop` command when permissions are required.
- Adjust `Access` command to use `IRCX_ERR_NOACCESS_913` instead of `IRCX_ERR_SECURITY_908` for consistency.