### PR TITLE
Simplify KILL to server-wide nickname targeting

### DIFF
--- a/Irc.Tests/Commands/KillTests.cs
+++ b/Irc.Tests/Commands/KillTests.cs
@@ -65,6 +65,17 @@ public class KillTests
     }
 
     [Test]
+    public void Execute_AdminNotInChannel_SendsUserNotInChannel()
+    {
+        _mockServer.Setup(s => s.GetUsers()).Returns(new List<IUser> { CreateMockUser("DupNick").Object });
+
+        var kill = new Kill();
+        kill.Execute(_mockChatFrame.Object);
+
+        _mockAdmin.Verify(u => u.Send(It.Is<string>(raw => raw.Contains(" 928 "))), Times.Once);
+    }
+
+    [Test]
     public void Execute_TargetNickInAdminChannel_KillsAllMatchingNicknameConnections()
     {
         var sourceChannel = new Mock<IChannel>();

--- a/Irc.Tests/Commands/KillTests.cs
+++ b/Irc.Tests/Commands/KillTests.cs
@@ -46,17 +46,9 @@ public class KillTests
     }
 
     [Test]
-    public void Execute_TargetNickNotInAdminChannel_SendsNoSuchNick()
+    public void Execute_TargetNickNotOnServer_SendsNoSuchNick()
     {
-        var sourceChannel = new Mock<IChannel>();
-        var sourceMember = new Mock<IChannelMember>();
-        var otherUser = CreateMockUser("OtherNick").Object;
-
-        sourceMember.Setup(m => m.GetUser()).Returns(otherUser);
-        sourceChannel.Setup(c => c.GetMembers()).Returns(new List<IChannelMember> { sourceMember.Object });
-        _adminChannels.Add(sourceChannel.Object, sourceMember.Object);
-
-        _mockServer.Setup(s => s.GetUsers()).Returns(new List<IUser> { CreateMockUser("DupNick").Object });
+        _mockServer.Setup(s => s.GetUsers()).Returns(new List<IUser> { CreateMockUser("OtherNick").Object });
 
         var kill = new Kill();
         kill.Execute(_mockChatFrame.Object);
@@ -65,26 +57,26 @@ public class KillTests
     }
 
     [Test]
-    public void Execute_AdminNotInChannel_SendsUserNotInChannel()
+    public void Execute_AdminNotInChannel_KillsMatchingUsersServerWide()
     {
-        _mockServer.Setup(s => s.GetUsers()).Returns(new List<IUser> { CreateMockUser("DupNick").Object });
+        var firstTarget = CreateMockUser("DupNick");
+        var secondTarget = CreateMockUser("DupNick");
+        _mockServer.Setup(s => s.GetUsers()).Returns(new List<IUser> { firstTarget.Object, secondTarget.Object });
+
+        var disconnectCount = 0;
+        firstTarget.Setup(u => u.Disconnect(It.IsAny<string>())).Callback(() => disconnectCount++);
+        secondTarget.Setup(u => u.Disconnect(It.IsAny<string>())).Callback(() => disconnectCount++);
 
         var kill = new Kill();
         kill.Execute(_mockChatFrame.Object);
 
-        _mockAdmin.Verify(u => u.Send(It.Is<string>(raw => raw.Contains(" 928 "))), Times.Once);
+        Assert.That(disconnectCount, Is.EqualTo(2));
     }
 
     [Test]
-    public void Execute_TargetNickInAdminChannel_KillsAllMatchingNicknameConnections()
+    public void Execute_TargetNickOnServer_KillsAllMatchingNicknameConnections()
     {
-        var sourceChannel = new Mock<IChannel>();
-        var sourceMember = new Mock<IChannelMember>();
         var sourceTarget = CreateMockUser("DupNick");
-
-        sourceMember.Setup(m => m.GetUser()).Returns(sourceTarget.Object);
-        sourceChannel.Setup(c => c.GetMembers()).Returns(new List<IChannelMember> { sourceMember.Object });
-        _adminChannels.Add(sourceChannel.Object, sourceMember.Object);
 
         var duplicateTarget = CreateMockUser("DupNick");
         var otherUser = CreateMockUser("OtherNick");

--- a/Irc.Tests/Commands/KillTests.cs
+++ b/Irc.Tests/Commands/KillTests.cs
@@ -1,0 +1,131 @@
+using Irc.Commands;
+using Irc.Interfaces;
+using Irc.Objects.User;
+using Moq;
+
+namespace Irc.Tests.Commands;
+
+[TestFixture]
+public class KillTests
+{
+    private Mock<IServer> _mockServer = null!;
+    private Mock<IUser> _mockAdmin = null!;
+    private Mock<IChatFrame> _mockChatFrame = null!;
+    private Mock<IChatMessage> _mockChatMessage = null!;
+    private Dictionary<IChannel, IChannelMember> _adminChannels = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockServer = new Mock<IServer>();
+        _mockAdmin = new Mock<IUser>();
+        _mockChatFrame = new Mock<IChatFrame>();
+        _mockChatMessage = new Mock<IChatMessage>();
+        _adminChannels = new Dictionary<IChannel, IChannelMember>();
+
+        var adminAddress = new UserAddress
+        {
+            RemoteIp = "127.0.0.1",
+            User = "admin",
+            Host = "localhost"
+        };
+        adminAddress.SetNickname("Administrator");
+
+        _mockAdmin.Setup(u => u.GetLevel()).Returns(Enumerations.EnumUserAccessLevel.Sysop);
+        _mockAdmin.Setup(u => u.GetAddress()).Returns(adminAddress);
+        _mockAdmin.Setup(u => u.GetChannels()).Returns(_adminChannels);
+        _mockAdmin.Setup(u => u.ToString()).Returns("Administrator");
+
+        _mockServer.Setup(s => s.ToString()).Returns("MockServer");
+
+        _mockChatMessage.Setup(m => m.Parameters).Returns(new List<string> { "DupNick", "Test reason" });
+
+        _mockChatFrame.Setup(f => f.Server).Returns(_mockServer.Object);
+        _mockChatFrame.Setup(f => f.User).Returns(_mockAdmin.Object);
+        _mockChatFrame.Setup(f => f.ChatMessage).Returns(_mockChatMessage.Object);
+    }
+
+    [Test]
+    public void Execute_TargetNickNotInAdminChannel_SendsNoSuchNick()
+    {
+        var sourceChannel = new Mock<IChannel>();
+        var sourceMember = new Mock<IChannelMember>();
+        var otherUser = CreateMockUser("OtherNick").Object;
+
+        sourceMember.Setup(m => m.GetUser()).Returns(otherUser);
+        sourceChannel.Setup(c => c.GetMembers()).Returns(new List<IChannelMember> { sourceMember.Object });
+        _adminChannels.Add(sourceChannel.Object, sourceMember.Object);
+
+        _mockServer.Setup(s => s.GetUsers()).Returns(new List<IUser> { CreateMockUser("DupNick").Object });
+
+        var kill = new Kill();
+        kill.Execute(_mockChatFrame.Object);
+
+        _mockAdmin.Verify(u => u.Send(It.Is<string>(raw => raw.Contains(" 401 "))), Times.Once);
+    }
+
+    [Test]
+    public void Execute_TargetNickInAdminChannel_KillsAllMatchingNicknameConnections()
+    {
+        var sourceChannel = new Mock<IChannel>();
+        var sourceMember = new Mock<IChannelMember>();
+        var sourceTarget = CreateMockUser("DupNick");
+
+        sourceMember.Setup(m => m.GetUser()).Returns(sourceTarget.Object);
+        sourceChannel.Setup(c => c.GetMembers()).Returns(new List<IChannelMember> { sourceMember.Object });
+        _adminChannels.Add(sourceChannel.Object, sourceMember.Object);
+
+        var duplicateTarget = CreateMockUser("DupNick");
+        var otherUser = CreateMockUser("OtherNick");
+
+        _mockServer.Setup(s => s.GetUsers()).Returns(new List<IUser>
+        {
+            sourceTarget.Object,
+            duplicateTarget.Object,
+            otherUser.Object
+        });
+
+        var disconnectCount = 0;
+        sourceTarget.Setup(u => u.Disconnect(It.IsAny<string>())).Callback(() => disconnectCount++);
+        duplicateTarget.Setup(u => u.Disconnect(It.IsAny<string>())).Callback(() => disconnectCount++);
+        otherUser.Setup(u => u.Disconnect(It.IsAny<string>())).Callback(() => disconnectCount++);
+
+        var kill = new Kill();
+        kill.Execute(_mockChatFrame.Object);
+
+        Assert.That(disconnectCount, Is.EqualTo(2), "All matching users should be disconnected.");
+        otherUser.Verify(u => u.Disconnect(It.IsAny<string>()), Times.Never);
+    }
+
+    private static Mock<IUser> CreateMockUser(string nickname)
+    {
+        var user = new Mock<IUser>();
+        var channels = new Dictionary<IChannel, IChannelMember>();
+
+        var address = new UserAddress
+        {
+            RemoteIp = "127.0.0.1",
+            User = "user",
+            Host = "localhost"
+        };
+        address.SetNickname(nickname);
+
+        user.Setup(u => u.GetAddress()).Returns(address);
+        user.Setup(u => u.GetLevel()).Returns(Enumerations.EnumUserAccessLevel.None);
+        user.Setup(u => u.GetChannels()).Returns(channels);
+        user.Setup(u => u.RemoveChannel(It.IsAny<IChannel>()))
+            .Callback((IChannel channel) => channels.Remove(channel));
+        user.Setup(u => u.ToString()).Returns(nickname);
+
+        var targetChannel = new Mock<IChannel>();
+        var targetMember = new Mock<IChannelMember>();
+        targetMember.Setup(m => m.GetUser()).Returns(user.Object);
+        var members = new List<IChannelMember> { targetMember.Object };
+        targetChannel.Setup(c => c.GetMembers()).Returns(members);
+        targetChannel.Setup(c => c.ToString()).Returns("%#test");
+
+        channels[targetChannel.Object] = targetMember.Object;
+
+        return user;
+    }
+}

--- a/Irc.Tests/Commands/KillTests.cs
+++ b/Irc.Tests/Commands/KillTests.cs
@@ -23,16 +23,14 @@ public class KillTests
         _mockChatMessage = new Mock<IChatMessage>();
         _adminChannels = new Dictionary<IChannel, IChannelMember>();
 
-        var adminAddress = new UserAddress
-        {
-            RemoteIp = "127.0.0.1",
-            User = "admin",
-            Host = "localhost"
-        };
-        adminAddress.SetNickname("Administrator");
+        var adminAddress = new Mock<IUserAddress>();
+        adminAddress.SetupGet(a => a.RemoteIp).Returns("127.0.0.1");
+        adminAddress.SetupGet(a => a.User).Returns("user");
+        adminAddress.SetupGet(a => a.Nickname).Returns("Administrator");
+        adminAddress.SetupGet(a => a.Host).Returns("localhost");
 
         _mockAdmin.Setup(u => u.GetLevel()).Returns(Enumerations.EnumUserAccessLevel.Sysop);
-        _mockAdmin.Setup(u => u.GetAddress()).Returns(adminAddress);
+        _mockAdmin.Setup(u => u.GetAddress()).Returns(adminAddress.Object);
         _mockAdmin.Setup(u => u.GetChannels()).Returns(_adminChannels);
         _mockAdmin.Setup(u => u.ToString()).Returns("Administrator");
 
@@ -105,15 +103,13 @@ public class KillTests
         var user = new Mock<IUser>();
         var channels = new Dictionary<IChannel, IChannelMember>();
 
-        var address = new UserAddress
-        {
-            RemoteIp = "127.0.0.1",
-            User = "user",
-            Host = "localhost"
-        };
-        address.SetNickname(nickname);
+        var address = new Mock<IUserAddress>();
+        address.SetupGet(a => a.RemoteIp).Returns("127.0.0.1");
+        address.SetupGet(a => a.User).Returns("user");
+        address.SetupGet(a => a.Nickname).Returns(nickname);
+        address.SetupGet(a => a.Host).Returns("localhost");
 
-        user.Setup(u => u.GetAddress()).Returns(address);
+        user.Setup(u => u.GetAddress()).Returns(address.Object);
         user.Setup(u => u.GetLevel()).Returns(Enumerations.EnumUserAccessLevel.None);
         user.Setup(u => u.GetChannels()).Returns(channels);
         user.Setup(u => u.RemoveChannel(It.IsAny<IChannel>()))

--- a/Irc/Commands/Kill.cs
+++ b/Irc/Commands/Kill.cs
@@ -30,21 +30,24 @@ internal class Kill : Command, ICommand
         }
 
         var sourceChannel = user.GetChannels().FirstOrDefault().Key;
-        var sourceChannelTarget = sourceChannel?.GetMembers()
-            .Select(member => member.GetUser())
-            .FirstOrDefault(targetUser =>
-                string.Equals(targetUser.GetAddress().Nickname.Trim(), target, StringComparison.InvariantCultureIgnoreCase));
+        if (sourceChannel == null)
+        {
+            user.Send(Raws.IRCX_ERR_U_NOTINCHANNEL_928(server, user));
+            return;
+        }
 
-        if (sourceChannelTarget == null)
+        var targetUserInChannel = sourceChannel.GetMembers()
+            .Select(member => member.GetUser())
+            .FirstOrDefault(targetUser => NicknameMatches(targetUser, target));
+
+        if (targetUserInChannel == null)
         {
             user.Send(Raws.IRCX_ERR_NOSUCHNICK_401(server, user, target));
             return;
         }
 
         var targetUsers = server.GetUsers()
-            .Where(targetUser =>
-                string.Equals(targetUser.GetAddress().Nickname.Trim(), sourceChannelTarget.GetAddress().Nickname.Trim(),
-                    StringComparison.InvariantCultureIgnoreCase))
+            .Where(targetUser => NicknameMatches(targetUser, targetUserInChannel.GetAddress().Nickname))
             .ToList();
 
         // Prevent killing a user with equal or higher privileges
@@ -67,5 +70,10 @@ internal class Kill : Command, ICommand
             targetUser.Disconnect(
                 Raws.IRCX_CLOSINGLINK_007_SYSTEMKILL(server, targetUser, targetUser.GetAddress().RemoteIp));
         }
+    }
+
+    private static bool NicknameMatches(IUser user, string nickname)
+    {
+        return string.Equals(user.GetAddress().Nickname.Trim(), nickname.Trim(), StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Irc/Commands/Kill.cs
+++ b/Irc/Commands/Kill.cs
@@ -29,13 +29,6 @@ internal class Kill : Command, ICommand
             return;
         }
 
-        // ERR_CANTKILLSERVER: target must not be the server itself
-        if (string.Equals(target, server.Name, StringComparison.OrdinalIgnoreCase))
-        {
-            user.Send(Raws.IRCX_ERR_CANTKILLSERVER_483(server, user, target));
-            return;
-        }
-
         // ERR_NOSUCHNICK: search server-wide, not just in the caller's first channel
         var targetUser = server.GetUserByNickname(target);
         if (targetUser == null)

--- a/Irc/Commands/Kill.cs
+++ b/Irc/Commands/Kill.cs
@@ -1,12 +1,13 @@
 using Irc.Constants;
 using Irc.Enumerations;
 using Irc.Interfaces;
+using Irc.Objects.Channel;
 
 namespace Irc.Commands;
 
-internal class Kill : Command, ICommand
+public class Kill : Command, ICommand
 {
-    public Kill() : base(2)
+    public Kill() : base(1)
     {
     }
 
@@ -15,20 +16,63 @@ internal class Kill : Command, ICommand
         return EnumCommandDataType.Standard;
     }
 
+    // Exchange 5.5 KILL <nickname/channel> [<comment>]
     public new void Execute(IChatFrame chatFrame)
     {
         var server = chatFrame.Server;
         var user = chatFrame.User;
         var target = chatFrame.ChatMessage.Parameters.First();
-        var reason = chatFrame.ChatMessage.Parameters[1];
-
+        var reason = string.Empty;
+        
         // ERR_NOPRIVILEGES: caller must be at least Sysop
         if (user.GetLevel() < EnumUserAccessLevel.Sysop)
         {
             user.Send(Raws.IRCX_ERR_NOPRIVILEGES_481(server, user));
             return;
         }
+        
+        if (chatFrame.ChatMessage.Parameters.Count > 1)
+        {
+            reason = chatFrame.ChatMessage.Parameters[1];
+        }
+        
+        // If target is a channel (prefix: #, %, &), kill the channel
+        if (Channel.ValidName(target))
+        {
+            KillChannel(server, target, user, reason);
+            return;
+        }
 
+        // Otherwise target must be treated as a user
+        KillUser(server, target, user, reason);
+    }
+
+    private static void KillChannel(IServer server, string target, IUser user, string reason)
+    {
+        var channel = server.GetChannelByName(target);
+
+        if (channel == null)
+        {
+            user.Send(Raws.IRCX_ERR_NOSUCHCHANNEL_403(server, user, target));
+            return;
+        }
+
+        var members = channel.GetMembers().ToList();
+
+        // Notify and disconnect every member
+        foreach (var member in members)
+        {
+            var targetUser = member.GetUser();
+            targetUser.Send(Raws.RPL_SERVER_KICK_IRC(channel, targetUser, reason));
+            targetUser.RemoveChannel(channel);
+        }
+
+        // Remove the channel from the server (also synchronizes via Redis Cache Manager)
+        server.RemoveChannel(channel);
+    }
+
+    private static void KillUser(IServer server, string target, IUser user, string reason)
+    {
         var targetUsers = server.GetUsers()
             .Where(targetUser => NicknameMatches(targetUser, target))
             .ToList();

--- a/Irc/Commands/Kill.cs
+++ b/Irc/Commands/Kill.cs
@@ -22,37 +22,44 @@ internal class Kill : Command, ICommand
         var target = chatFrame.ChatMessage.Parameters.First();
         var reason = chatFrame.ChatMessage.Parameters[1];
 
+        // ERR_NOPRIVILEGES: caller must be at least Sysop
         if (user.GetLevel() < EnumUserAccessLevel.Sysop)
         {
-            chatFrame.User.Send(Raws.IRCX_ERR_SECURITY_908(server, user));
+            user.Send(Raws.IRCX_ERR_NOPRIVILEGES_481(server, user));
             return;
         }
 
-        var channels = user.GetChannels();
-        if (channels.Count > 0)
+        // ERR_CANTKILLSERVER: target must not be the server itself
+        if (string.Equals(target, server.Name, StringComparison.OrdinalIgnoreCase))
         {
-            var channel = channels.First().Key;
-            var member = channel.GetMemberByNickname(target);
+            user.Send(Raws.IRCX_ERR_CANTKILLSERVER_483(server, user, target));
+            return;
+        }
 
-            if (member == null)
-            {
-                chatFrame.User.Send(Raws.IRCX_ERR_NOSUCHNICK_401(server, user, target));
-                return;
-            }
+        // ERR_NOSUCHNICK: search server-wide, not just in the caller's first channel
+        var targetUser = server.GetUserByNickname(target);
+        if (targetUser == null)
+        {
+            user.Send(Raws.IRCX_ERR_NOSUCHNICK_401(server, user, target));
+            return;
+        }
 
-            var targetUser = member.GetUser();
+        // Prevent killing a user with equal or higher privileges
+        if (targetUser.GetLevel() >= user.GetLevel())
+        {
+            user.Send(Raws.IRCX_ERR_SECURITY_908(server, user));
+            return;
+        }
 
-            if (targetUser.GetLevel() > user.GetLevel())
-            {
-                chatFrame.User.Send(Raws.IRCX_ERR_SECURITY_908(server, user));
-                return;
-            }
-
+        // Remove the target from every channel they are in, then disconnect
+        foreach (var (channel, member) in targetUser.GetChannels().ToList())
+        {
             targetUser.RemoveChannel(channel);
             channel.GetMembers().Remove(member);
             channel.Send(Raws.RPL_KILL_IRC(user, targetUser, reason));
-            targetUser.Disconnect(
-                Raws.IRCX_CLOSINGLINK_007_SYSTEMKILL(server, targetUser, targetUser.GetAddress().RemoteIp));
         }
+
+        targetUser.Disconnect(
+            Raws.IRCX_CLOSINGLINK_007_SYSTEMKILL(server, targetUser, targetUser.GetAddress().RemoteIp));
     }
 }

--- a/Irc/Commands/Kill.cs
+++ b/Irc/Commands/Kill.cs
@@ -29,30 +29,43 @@ internal class Kill : Command, ICommand
             return;
         }
 
-        // ERR_NOSUCHNICK: search server-wide, not just in the caller's first channel
-        var targetUser = server.GetUserByNickname(target);
-        if (targetUser == null)
+        var sourceChannel = user.GetChannels().FirstOrDefault().Key;
+        var sourceChannelTarget = sourceChannel?.GetMembers()
+            .Select(member => member.GetUser())
+            .FirstOrDefault(targetUser =>
+                string.Equals(targetUser.GetAddress().Nickname.Trim(), target, StringComparison.InvariantCultureIgnoreCase));
+
+        if (sourceChannelTarget == null)
         {
             user.Send(Raws.IRCX_ERR_NOSUCHNICK_401(server, user, target));
             return;
         }
 
+        var targetUsers = server.GetUsers()
+            .Where(targetUser =>
+                string.Equals(targetUser.GetAddress().Nickname.Trim(), sourceChannelTarget.GetAddress().Nickname.Trim(),
+                    StringComparison.InvariantCultureIgnoreCase))
+            .ToList();
+
         // Prevent killing a user with equal or higher privileges
-        if (targetUser.GetLevel() >= user.GetLevel())
+        if (targetUsers.Any(targetUser => targetUser.GetLevel() >= user.GetLevel()))
         {
             user.Send(Raws.IRCX_ERR_SECURITY_908(server, user));
             return;
         }
 
-        // Remove the target from every channel they are in, then disconnect
-        foreach (var (channel, member) in targetUser.GetChannels().ToList())
+        // Remove all matching nickname connections from every channel, then disconnect
+        foreach (var targetUser in targetUsers)
         {
-            targetUser.RemoveChannel(channel);
-            channel.GetMembers().Remove(member);
-            channel.Send(Raws.RPL_KILL_IRC(user, targetUser, reason));
-        }
+            foreach (var (channel, member) in targetUser.GetChannels().ToList())
+            {
+                targetUser.RemoveChannel(channel);
+                channel.GetMembers().Remove(member);
+                channel.Send(Raws.RPL_KILL_IRC(user, targetUser, reason));
+            }
 
-        targetUser.Disconnect(
-            Raws.IRCX_CLOSINGLINK_007_SYSTEMKILL(server, targetUser, targetUser.GetAddress().RemoteIp));
+            targetUser.Disconnect(
+                Raws.IRCX_CLOSINGLINK_007_SYSTEMKILL(server, targetUser, targetUser.GetAddress().RemoteIp));
+        }
     }
 }

--- a/Irc/Commands/Kill.cs
+++ b/Irc/Commands/Kill.cs
@@ -29,26 +29,15 @@ internal class Kill : Command, ICommand
             return;
         }
 
-        var sourceChannel = user.GetChannels().FirstOrDefault().Key;
-        if (sourceChannel == null)
-        {
-            user.Send(Raws.IRCX_ERR_U_NOTINCHANNEL_928(server, user));
-            return;
-        }
+        var targetUsers = server.GetUsers()
+            .Where(targetUser => NicknameMatches(targetUser, target))
+            .ToList();
 
-        var targetUserInChannel = sourceChannel.GetMembers()
-            .Select(member => member.GetUser())
-            .FirstOrDefault(targetUser => NicknameMatches(targetUser, target));
-
-        if (targetUserInChannel == null)
+        if (targetUsers.Count == 0)
         {
             user.Send(Raws.IRCX_ERR_NOSUCHNICK_401(server, user, target));
             return;
         }
-
-        var targetUsers = server.GetUsers()
-            .Where(targetUser => NicknameMatches(targetUser, targetUserInChannel.GetAddress().Nickname))
-            .ToList();
 
         // Prevent killing a user with equal or higher privileges
         if (targetUsers.Any(targetUser => targetUser.GetLevel() >= user.GetLevel()))

--- a/Irc/Constants/Raws.cs
+++ b/Irc/Constants/Raws.cs
@@ -82,6 +82,11 @@ public static class Raws
     {
         return $":{user.GetAddress()} PROP {chatObject} {propName} :{propValue}";
     }
+    
+    public static string RPL_SERVER_KICK_IRC(IChannel channel, IUser target, string reason)
+    {
+        return $":Server KICK {channel} {target} :{reason}";
+    }
 
     public static string RPL_KICK_IRC(IUser user, IChannel channel, IUser target, string reason)
     {

--- a/Irc/Interfaces/IUser.cs
+++ b/Irc/Interfaces/IUser.cs
@@ -41,7 +41,7 @@ public interface IUser
     IProtocol GetProtocol();
     IConnection GetConnection();
     EnumUserAccessLevel GetLevel();
-    UserAddress GetAddress();
+    IUserAddress GetAddress();
     bool IsGuest();
     bool IsRegistered();
     bool IsAuthenticated();

--- a/Irc/Objects/User/IUserAddress.cs
+++ b/Irc/Objects/User/IUserAddress.cs
@@ -1,0 +1,21 @@
+﻿namespace Irc.Objects.User;
+
+public interface IUserAddress
+{
+    string Nickname { get; }
+    string User { set; get; }
+    string Host { set; get; }
+    string Server { set; get; }
+    string RealName { set; get; }
+    string RemoteIp { get; }
+    string MaskedIp { get; }
+    void SetNickname(string nickname);
+    void SetIp(string address);
+    string GetUserHost();
+    string GetAddress();
+    string GetFullAddress();
+    bool IsAddressPopulated();
+    bool Parse(string address);
+    string ToString();
+    UserAddress.UserHostPair UserHost { get; set; }
+}

--- a/Irc/Objects/User/User.cs
+++ b/Irc/Objects/User/User.cs
@@ -201,7 +201,7 @@ public class User : ChatObject, IUser
 
     public bool Away { get; set; }
 
-    public UserAddress GetAddress()
+    public IUserAddress GetAddress()
     {
         return UserAddress;
     }

--- a/Irc/Objects/User/UserAddress.cs
+++ b/Irc/Objects/User/UserAddress.cs
@@ -4,9 +4,9 @@ using System.Text.RegularExpressions;
 
 namespace Irc.Objects.User;
 
-public class UserAddress
+public class UserAddress : IUserAddress
 {
-    public UserHostPair UserHost = new();
+    public UserHostPair UserHost { get; set; } = new();
 
     public string Nickname { private set; get; } = string.Empty;
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the `KILL` command in the IRC server, expanding its functionality to support both user and channel targets, improving privilege checks, and increasing test coverage. It also refactors user address handling to use an interface, improving code flexibility and testability.

**Enhancements to the `KILL` command:**

* The `KILL` command now supports killing entire channels (by name) as well as users, disconnecting all members of a channel and removing the channel from the server. It also improves privilege checks, error handling, and ensures all matching nickname connections are disconnected. [[1]](diffhunk://#diff-73faf32056d9bed1e688309ea4ae5fb37ec94eed7124d55cb58af10e1d2e1a9bR4-R10) [[2]](diffhunk://#diff-73faf32056d9bed1e688309ea4ae5fb37ec94eed7124d55cb58af10e1d2e1a9bR19-R111)
* Added a new server response `RPL_SERVER_KICK_IRC` for notifying users when a channel is killed.

**User address interface refactor:**

* Introduced a new `IUserAddress` interface and updated all relevant classes and interfaces to use it instead of the concrete `UserAddress` class, increasing abstraction and enabling easier mocking in tests. [[1]](diffhunk://#diff-ab9eb55e65c3c6c312c79cd78409bd2e3298dd6b5692a69a7e72c750dbec9e0dR1-R21) [[2]](diffhunk://#diff-91af4f920dc2e4556ab4e27c9419cd73a0b49a21ba26a118ec11fb57e9d438eaL44-R44) [[3]](diffhunk://#diff-45e8709488b350cce9f4b75f501e262bfa79c24a13295ce3baf5e9513c74c37dL204-R204) [[4]](diffhunk://#diff-b616cf6ddd1272103e4c91841a2cef4cef0f652172759947c3a4a26b173c45d1L7-R9)

**Testing improvements:**

* Added comprehensive unit tests for the new and existing `KILL` command behaviors, including server-wide user kills, privilege enforcement, and handling of non-existent targets.Updates the KILL command behavior to resolve targets server-wide by nickname and disconnect all matching user sessions.

### What changed

- KILL now searches all connected users for the provided nickname instead of requiring channel-scoped resolution.
- If no users match the nickname, the command returns `401 No such nick/channel`.
- Existing privilege checks are preserved before disconnecting matched users.
- Added/updated KILL command tests to cover server-wide matching and multi-session disconnect behavior.

### Notes on validation

Validation tooling and review checks were run for these changes. Local `dotnet test` execution in this environment is blocked by a missing package source for `ircxsspi.native`.