### PR TITLE
fix(prop): Send empty 819 for no-PUID targets; emit G member flag

### DIFF
--- a/Irc.ChatServer.Daemon/Program.cs
+++ b/Irc.ChatServer.Daemon/Program.cs
@@ -38,6 +38,7 @@ internal class Program
             socketServer.OnListen += (_, __) => DisplayStartupInfo(options, ip);
 
             var defaultPermissions = await LoadDefaultPermissions();
+            DefaultPermissions.Initialize(defaultPermissions);
 
             try
             {

--- a/Irc.Directory.Daemon/Program.cs
+++ b/Irc.Directory.Daemon/Program.cs
@@ -35,6 +35,7 @@ internal class Program
 			socketServer.OnListen += (_, __) => DisplayStartupInfo(options, ip);
 
 			var defaultPermissions = await LoadDefaultPermissions();
+			DefaultPermissions.Initialize(defaultPermissions);
 			var floodProtectionManager = new FloodProtectionManager();
 			var dataStoreServerConfig = new DataStore(ResolveRuntimePath("DefaultServer.json"));
 

--- a/Irc.Tests/Commands/PropSendPropsTests.cs
+++ b/Irc.Tests/Commands/PropSendPropsTests.cs
@@ -213,8 +213,8 @@ public class PropSendPropsTests
             Nickname = nickname
         };
 
-        user.SetGuest(guest);
         user.InitializeSspiHandler(passport);
+        if (!guest && passport) user.AssignPassportProfile();
         return user;
     }
 }

--- a/Irc.Tests/Commands/PropSendPropsTests.cs
+++ b/Irc.Tests/Commands/PropSendPropsTests.cs
@@ -1,0 +1,220 @@
+using Irc.Enumerations;
+using Irc.Interfaces;
+using Irc.Objects;
+using Irc.Objects.Channel;
+using Irc.Objects.User;
+using Moq;
+
+namespace Irc.Tests.Commands;
+
+[TestFixture]
+public class PropSendPropsTests
+{
+    private Prop _propCommand = null!;
+    private PropPuid _puidProp = null!;
+    private Mock<IServer> _mockServer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _propCommand = new Prop();
+        _puidProp = new PropPuid();
+        _mockServer = new Mock<IServer>();
+        _mockServer.Setup(s => s.DisableGuestMode).Returns(false);
+        _mockServer.Setup(s => s.ToString()).Returns("TestServer");
+        _mockServer.Setup(s => s.Name).Returns("TestServer");
+    }
+
+    [Test]
+    public void SendProps_NoPuidCoMember_Sends819Only()
+    {
+        var capturedMessages = new List<string>();
+        var source = CreateUser("Source", guest: false, passport: false,
+            capturedMessages: capturedMessages);
+        var target = CreateUser("Target", guest: false, passport: false);
+
+        var channel = new Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        _propCommand.SendProps(_mockServer.Object, source, target,
+            new List<IPropRule> { _puidProp });
+
+        var count819 = capturedMessages.Count(m => m.Contains(" 819 "));
+        var count818 = capturedMessages.Count(m => m.Contains(" 818 "));
+        var count908 = capturedMessages.Count(m => m.Contains(" 908 "));
+
+        Assert.That(count819, Is.EqualTo(1), "Expected exactly one IRCX_RPL_PROPEND_819");
+        Assert.That(count818, Is.EqualTo(0), "Expected zero IRCX_RPL_PROPLIST_818 (no PUID)");
+        Assert.That(count908, Is.EqualTo(0), "Expected zero IRCX_ERR_SECURITY_908 (SC-184-01: no-PUID returns empty, not denial)");
+    }
+
+    [Test]
+    public void SendProps_NonCoMember_SingleProp_Sends908Only()
+    {
+        var capturedMessages = new List<string>();
+        var source = CreateUser("Source", guest: false, passport: false,
+            capturedMessages: capturedMessages);
+        var target = CreateUser("Target", guest: false, passport: true, puid: "DEADBEEF01234567");
+
+        _propCommand.SendProps(_mockServer.Object, source, target,
+            new List<IPropRule> { _puidProp });
+
+        var count908 = capturedMessages.Count(m => m.Contains(" 908 "));
+        var count818 = capturedMessages.Count(m => m.Contains(" 818 "));
+        var count819 = capturedMessages.Count(m => m.Contains(" 819 "));
+
+        Assert.That(count908, Is.EqualTo(1), "Expected exactly one IRCX_ERR_SECURITY_908 for non-co-member");
+        Assert.That(count818, Is.EqualTo(0), "Expected zero IRCX_RPL_PROPLIST_818");
+        Assert.That(count819, Is.EqualTo(0), "Expected zero IRCX_RPL_PROPEND_819 (no emptyProp, no propsSent)");
+    }
+
+    [Test]
+    public void SendProps_PassportCoMember_Sends818WithPuidThen819()
+    {
+        const string puid = "F21F6EA24E994BAB";
+        var capturedMessages = new List<string>();
+        var source = CreateUser("Source", guest: false, passport: false,
+            capturedMessages: capturedMessages);
+        var target = CreateUser("Target", guest: false, passport: true, puid: puid);
+
+        var channel = new Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        _propCommand.SendProps(_mockServer.Object, source, target,
+            new List<IPropRule> { _puidProp });
+
+        var msg818 = capturedMessages.Where(m => m.Contains(" 818 ")).ToList();
+        var count819 = capturedMessages.Count(m => m.Contains(" 819 "));
+        var count908 = capturedMessages.Count(m => m.Contains(" 908 "));
+
+        Assert.That(msg818, Has.Count.EqualTo(1), "Expected exactly one IRCX_RPL_PROPLIST_818");
+        Assert.That(msg818[0], Does.Contain("PUID"), "818 message must name the PUID property");
+        Assert.That(msg818[0], Does.Contain(puid),
+            $"818 message must carry the PUID value '{puid}'");
+        Assert.That(count819, Is.EqualTo(1), "Expected exactly one IRCX_RPL_PROPEND_819 terminator");
+        Assert.That(count908, Is.EqualTo(0), "Expected zero 908 for a co-member passport query");
+    }
+
+    [Test]
+    public void SendProps_GuestCoMember_Sends819Only()
+    {
+        var capturedMessages = new List<string>();
+        var source = CreateUser("Source", guest: false, passport: false,
+            capturedMessages: capturedMessages);
+        var target = CreateUser("Target", guest: true, passport: false);
+
+        var channel = new Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        _propCommand.SendProps(_mockServer.Object, source, target,
+            new List<IPropRule> { _puidProp });
+
+        var count819 = capturedMessages.Count(m => m.Contains(" 819 "));
+        var count818 = capturedMessages.Count(m => m.Contains(" 818 "));
+        var count908 = capturedMessages.Count(m => m.Contains(" 908 "));
+
+        Assert.That(count819, Is.EqualTo(1), "Guest target must yield empty property list (819)");
+        Assert.That(count818, Is.EqualTo(0), "No 818 for guest target");
+        Assert.That(count908, Is.EqualTo(0), "No 908 for guest co-member (SC-184-01)");
+    }
+
+    [Test]
+    public void SendProps_NonCoMember_MultipleProps_Sends_No908()
+    {
+        var capturedMessages = new List<string>();
+        var source = CreateUser("Source", guest: false, passport: false,
+            capturedMessages: capturedMessages);
+        var target = CreateUser("Target", guest: false, passport: true, puid: "AABBCCDD11223344");
+
+        _propCommand.SendProps(_mockServer.Object, source, target,
+            new List<IPropRule> { _puidProp, _puidProp });
+
+        var count908 = capturedMessages.Count(m => m.Contains(" 908 "));
+
+        Assert.That(count908, Is.EqualTo(0),
+            "908 must only be emitted when props.Count==1 (single-prop permission denial)");
+    }
+
+    [Test]
+    public void SendProps_DeterministicForRepeatedCalls()
+    {
+        var captured1 = new List<string>();
+        var captured2 = new List<string>();
+
+        var source1 = CreateUser("Src1", guest: false, passport: false, capturedMessages: captured1);
+        var target1 = CreateUser("Tgt1", guest: false, passport: false);
+        var channel1 = new Channel("#Chan1");
+        channel1.Join(source1);
+        channel1.Join(target1);
+
+        var source2 = CreateUser("Src2", guest: false, passport: false, capturedMessages: captured2);
+        var target2 = CreateUser("Tgt2", guest: false, passport: false);
+        var channel2 = new Channel("#Chan2");
+        channel2.Join(source2);
+        channel2.Join(target2);
+
+        _propCommand.SendProps(_mockServer.Object, source1, target1,
+            new List<IPropRule> { _puidProp });
+        _propCommand.SendProps(_mockServer.Object, source2, target2,
+            new List<IPropRule> { _puidProp });
+
+        var count819_1 = captured1.Count(m => m.Contains(" 819 "));
+        var count819_2 = captured2.Count(m => m.Contains(" 819 "));
+        var count818_1 = captured1.Count(m => m.Contains(" 818 "));
+        var count818_2 = captured2.Count(m => m.Contains(" 818 "));
+
+        Assert.That(count819_1, Is.EqualTo(count819_2), "819 counts must be identical across runs");
+        Assert.That(count818_1, Is.EqualTo(count818_2), "818 counts must be identical across runs");
+    }
+
+    private User CreateUser(
+        string nickname,
+        bool guest,
+        bool passport,
+        string puid = "",
+        List<string>? capturedMessages = null)
+    {
+        var mockConnection = new Mock<IConnection>();
+        var mockProtocol = new Mock<IProtocol>();
+        var mockDataRegulator = new Mock<IDataRegulator>();
+        var mockFloodProtectionProfile = new Mock<IFloodProtectionProfile>();
+        var mockSaslHandler = new Mock<ISaslHandler>();
+        var mockCredential = new Mock<ICredential>();
+
+        mockConnection.Setup(x => x.GetIp()).Returns("127.0.0.1");
+        mockProtocol.Setup(p => p.GetProtocolType()).Returns(EnumProtocolType.IRC8);
+        mockSaslHandler.Setup(h => h.RequiresPassport).Returns(passport);
+        mockCredential.Setup(c => c.Username).Returns(puid);
+        mockSaslHandler.Setup(h => h.GetCredentials()).Returns(mockCredential.Object);
+
+        if (capturedMessages != null)
+        {
+            mockDataRegulator
+                .Setup(d => d.PushOutgoing(It.IsAny<string>()))
+                .Callback<string>(capturedMessages.Add)
+                .Returns(0);
+        }
+        else
+        {
+            mockDataRegulator.Setup(d => d.PushOutgoing(It.IsAny<string>())).Returns(0);
+        }
+
+        var user = new User(
+            mockConnection.Object,
+            mockProtocol.Object,
+            mockDataRegulator.Object,
+            mockFloodProtectionProfile.Object,
+            _mockServer.Object,
+            _ => mockSaslHandler.Object)
+        {
+            Nickname = nickname
+        };
+
+        user.SetGuest(guest);
+        user.InitializeSspiHandler(passport);
+        return user;
+    }
+}

--- a/Irc.Tests/Objects/PropPuidTests.cs
+++ b/Irc.Tests/Objects/PropPuidTests.cs
@@ -151,7 +151,7 @@ public class PropPuidTests
     }
 
     [Test]
-    public void FlagAndReply_NoPuidCoMember_GenderIsG_AndEvaluateGetIsNoValue()
+    public void FlagAndReply_NoPuidCoMember_IsGuest_FlagG_AndEvaluateGetIsNoValue()
     {
         var source = CreateUser(guest: false, passport: false);
         var target = CreateUser(guest: false, passport: false);
@@ -159,30 +159,35 @@ public class PropPuidTests
         channel.Join(source);
         channel.Join(target);
 
-        var genderString = target.GetProfile().GetGenderString();
         var evaluateResult = _prop.EvaluateGet(source, target);
 
-        Assert.That(genderString, Is.EqualTo("G"),
+        Assert.That(target.GetProfile(), Is.Null,
+            "A no-PUID target has no profile object");
+        Assert.That(target.IsGuest(), Is.True,
+            "A no-PUID target is a guest");
+        Assert.That(target.GetFormattedProfile(EnumProtocolType.IRC8), Is.EqualTo("H,U,GO"),
             "No-PUID target must report gender 'G'");
         Assert.That(evaluateResult, Is.EqualTo(EnumIrcError.NO_VALUE),
             "No-PUID target must yield NO_VALUE (empty 819), not a denial");
     }
 
     [Test]
-    public void FlagAndReply_PassportCoMember_GenderNotG_AndEvaluateGetIsOk()
+    public void FlagAndReply_PassportCoMember_NotGuest_FlagNotG_AndEvaluateGetIsOk()
     {
         var source = CreateUser(guest: false, passport: false);
         var target = CreateUser(guest: false, passport: true, puid: "F21F6EA24E994BAB");
-        target.GetProfile().HasPuid = true;
         var channel = new Irc.Objects.Channel.Channel("#TestChannel");
         channel.Join(source);
         channel.Join(target);
 
-        var genderString = target.GetProfile().GetGenderString();
         var evaluateResult = _prop.EvaluateGet(source, target);
 
-        Assert.That(genderString, Is.Not.EqualTo("G"),
-            "Passport target with HasPuid=true must not produce 'G'");
+        Assert.That(target.GetProfile(), Is.Not.Null,
+            "A passport target has a profile object");
+        Assert.That(target.IsGuest(), Is.False,
+            "A passport target is not a guest");
+        Assert.That(target.GetFormattedProfile(EnumProtocolType.IRC8), Is.EqualTo("H,U,RXO"),
+            "Passport target must not produce the no-profile 'G' flag");
         Assert.That(evaluateResult, Is.EqualTo(EnumIrcError.OK),
             "Passport target must yield OK");
     }
@@ -214,8 +219,8 @@ public class PropPuidTests
             Nickname = $"User_{Guid.NewGuid():N}"
         };
 
-        user.SetGuest(guest);
         user.InitializeSspiHandler(passport);
+        if (!guest && passport) user.AssignPassportProfile();
         return user;
     }
 

--- a/Irc.Tests/Objects/PropPuidTests.cs
+++ b/Irc.Tests/Objects/PropPuidTests.cs
@@ -1,0 +1,244 @@
+using Irc.Enumerations;
+using Irc.Interfaces;
+using Irc.Objects.Channel;
+using Irc.Objects.User;
+using Moq;
+
+namespace Irc.Tests.Objects;
+
+[TestFixture]
+public class PropPuidTests
+{
+    private PropPuid _prop = null!;
+    private Mock<IServer> _mockServer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _prop = new PropPuid();
+        _mockServer = new Mock<IServer>();
+        _mockServer.Setup(s => s.DisableGuestMode).Returns(false);
+        _mockServer.Setup(s => s.ToString()).Returns("TestServer");
+    }
+
+    [Test]
+    public void EvaluateGet_NonUserSource_ReturnsErrNoperms()
+    {
+        var mockSource = new Mock<IChatObject>();
+        var target = CreateUser(guest: false, passport: false);
+
+        var result = _prop.EvaluateGet(mockSource.Object, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.ERR_NOPERMS));
+    }
+
+    [Test]
+    public void EvaluateGet_NonUserTarget_ReturnsErrNoperms()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var mockTarget = new Mock<IChatObject>();
+
+        var result = _prop.EvaluateGet(source, mockTarget.Object);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.ERR_NOPERMS));
+    }
+
+    [Test]
+    public void EvaluateGet_GateFirst_PassportTarget_NoSharedChannel_ReturnsErrNoperms()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUser(guest: false, passport: true, puid: "DEADBEEFDEADBEEF");
+
+        var result = _prop.EvaluateGet(source, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.ERR_NOPERMS),
+            "Access gate must fire before PUID classification even for passport targets");
+    }
+
+    [Test]
+    public void EvaluateGet_GateFirst_GuestTarget_NoSharedChannel_ReturnsErrNoperms()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUser(guest: true, passport: false);
+
+        var result = _prop.EvaluateGet(source, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.ERR_NOPERMS),
+            "Access gate must fire before guest classification");
+    }
+
+    [Test]
+    public void EvaluateGet_CoMember_GuestTarget_ReturnsNoValue()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUser(guest: true, passport: false);
+        var channel = new Irc.Objects.Channel.Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        var result = _prop.EvaluateGet(source, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.NO_VALUE));
+    }
+
+    [Test]
+    public void EvaluateGet_CoMember_NullSspiHandler_ReturnsNoValue()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUserNoSspi();
+        var channel = new Irc.Objects.Channel.Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        var result = _prop.EvaluateGet(source, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.NO_VALUE));
+    }
+
+    [Test]
+    public void EvaluateGet_CoMember_NonPassportTarget_ReturnsNoValue()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUser(guest: false, passport: false);
+        var channel = new Irc.Objects.Channel.Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        var result = _prop.EvaluateGet(source, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.NO_VALUE));
+    }
+
+    [Test]
+    public void EvaluateGet_CoMember_PassportTarget_ReturnsOk()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUser(guest: false, passport: true, puid: "F21F6EA24E994BAB");
+        var channel = new Irc.Objects.Channel.Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        var result = _prop.EvaluateGet(source, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.OK));
+    }
+
+    [Test]
+    public void EvaluateGet_SelfQuery_PassportUser_ReturnsOk()
+    {
+        var user = CreateUser(guest: false, passport: true, puid: "SELFPUIDHEX01234");
+        var channel = new Irc.Objects.Channel.Channel("#TestChannel");
+        channel.Join(user);
+
+        var result = _prop.EvaluateGet(user, user);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.OK));
+    }
+
+    [Test]
+    public void EvaluateGet_DifferentChannels_NoOverlap_ReturnsErrNoperms()
+    {
+        var source = CreateUser(guest: false, passport: true, puid: "SOURCEPUID");
+        var target = CreateUser(guest: false, passport: true, puid: "TARGETPUID");
+        var channelA = new Irc.Objects.Channel.Channel("#ChannelA");
+        var channelB = new Irc.Objects.Channel.Channel("#ChannelB");
+        channelA.Join(source);
+        channelB.Join(target);
+
+        var result = _prop.EvaluateGet(source, target);
+
+        Assert.That(result, Is.EqualTo(EnumIrcError.ERR_NOPERMS));
+    }
+
+    [Test]
+    public void FlagAndReply_NoPuidCoMember_GenderIsG_AndEvaluateGetIsNoValue()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUser(guest: false, passport: false);
+        var channel = new Irc.Objects.Channel.Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        var genderString = target.GetProfile().GetGenderString();
+        var evaluateResult = _prop.EvaluateGet(source, target);
+
+        Assert.That(genderString, Is.EqualTo("G"),
+            "No-PUID target must report gender 'G'");
+        Assert.That(evaluateResult, Is.EqualTo(EnumIrcError.NO_VALUE),
+            "No-PUID target must yield NO_VALUE (empty 819), not a denial");
+    }
+
+    [Test]
+    public void FlagAndReply_PassportCoMember_GenderNotG_AndEvaluateGetIsOk()
+    {
+        var source = CreateUser(guest: false, passport: false);
+        var target = CreateUser(guest: false, passport: true, puid: "F21F6EA24E994BAB");
+        target.GetProfile().HasPuid = true;
+        var channel = new Irc.Objects.Channel.Channel("#TestChannel");
+        channel.Join(source);
+        channel.Join(target);
+
+        var genderString = target.GetProfile().GetGenderString();
+        var evaluateResult = _prop.EvaluateGet(source, target);
+
+        Assert.That(genderString, Is.Not.EqualTo("G"),
+            "Passport target with HasPuid=true must not produce 'G'");
+        Assert.That(evaluateResult, Is.EqualTo(EnumIrcError.OK),
+            "Passport target must yield OK");
+    }
+
+    private Irc.Objects.User.User CreateUser(bool guest, bool passport, string puid = "")
+    {
+        var mockConnection = new Mock<IConnection>();
+        var mockProtocol = new Mock<IProtocol>();
+        var mockDataRegulator = new Mock<IDataRegulator>();
+        var mockFloodProtectionProfile = new Mock<IFloodProtectionProfile>();
+        var mockSaslHandler = new Mock<ISaslHandler>();
+        var mockCredential = new Mock<ICredential>();
+
+        mockConnection.Setup(x => x.GetIp()).Returns("127.0.0.1");
+        mockProtocol.Setup(p => p.GetProtocolType()).Returns(EnumProtocolType.IRC8);
+        mockDataRegulator.Setup(d => d.PushOutgoing(It.IsAny<string>())).Returns(0);
+        mockSaslHandler.Setup(h => h.RequiresPassport).Returns(passport);
+        mockCredential.Setup(c => c.Username).Returns(puid);
+        mockSaslHandler.Setup(h => h.GetCredentials()).Returns(mockCredential.Object);
+
+        var user = new Irc.Objects.User.User(
+            mockConnection.Object,
+            mockProtocol.Object,
+            mockDataRegulator.Object,
+            mockFloodProtectionProfile.Object,
+            _mockServer.Object,
+            _ => mockSaslHandler.Object)
+        {
+            Nickname = $"User_{Guid.NewGuid():N}"
+        };
+
+        user.SetGuest(guest);
+        user.InitializeSspiHandler(passport);
+        return user;
+    }
+
+    private Irc.Objects.User.User CreateUserNoSspi()
+    {
+        var mockConnection = new Mock<IConnection>();
+        var mockProtocol = new Mock<IProtocol>();
+        var mockDataRegulator = new Mock<IDataRegulator>();
+        var mockFloodProtectionProfile = new Mock<IFloodProtectionProfile>();
+
+        mockConnection.Setup(x => x.GetIp()).Returns("127.0.0.1");
+        mockProtocol.Setup(p => p.GetProtocolType()).Returns(EnumProtocolType.IRC8);
+        mockDataRegulator.Setup(d => d.PushOutgoing(It.IsAny<string>())).Returns(0);
+
+        return new Irc.Objects.User.User(
+            mockConnection.Object,
+            mockProtocol.Object,
+            mockDataRegulator.Object,
+            mockFloodProtectionProfile.Object,
+            _mockServer.Object,
+            _ => throw new InvalidOperationException("SSPI factory must not be called for no-SSPI user"))
+        {
+            Nickname = $"NoSspiUser_{Guid.NewGuid():N}"
+        };
+    }
+}

--- a/Irc.Tests/Objects/User/UserProfileTests.cs
+++ b/Irc.Tests/Objects/User/UserProfileTests.cs
@@ -1,0 +1,185 @@
+using Irc.Enumerations;
+using Irc.Objects.User;
+
+namespace Irc.Tests.Objects.User;
+
+[TestFixture]
+public class UserProfileTests
+{
+    [Test]
+    public void GetGenderString_Guest_ReturnsG()
+    {
+        var profile = new UserProfile { Guest = true };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("G"));
+    }
+
+    [Test]
+    public void GetPictureString_Guest_ReturnsEmpty()
+    {
+        var profile = new UserProfile { Guest = true };
+
+        Assert.That(profile.GetPictureString(), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void GetGenderString_NonGuest_NoPuid_ReturnsG()
+    {
+        var profile = new UserProfile { Guest = false, HasPuid = false };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("G"));
+    }
+
+    [Test]
+    public void GetPictureString_NonGuest_NoPuid_ReturnsEmpty()
+    {
+        var profile = new UserProfile { Guest = false, HasPuid = false };
+
+        Assert.That(profile.GetPictureString(), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void ToString_NonGuest_NoPuid_NotRegistered_EndsWithGO()
+    {
+        var profile = new UserProfile
+        {
+            Guest = false,
+            HasPuid = false,
+            Registered = false,
+            Away = false,
+            Level = EnumUserAccessLevel.None
+        };
+
+        var result = profile.ToString();
+
+        Assert.That(result, Does.EndWith("GO"),
+            $"Expected profile string to end with 'GO' for a no-PUID non-guest user; got '{result}'");
+    }
+
+    [Test]
+    public void GetGenderString_HasPuid_NoProfile_ReturnsR()
+    {
+        var profile = new UserProfile { Guest = false, HasPuid = true, HasProfile = false };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("R"));
+    }
+
+    [Test]
+    public void GetProfileString_HasPuid_Male_HasPicture_ReturnsMY()
+    {
+        var profile = new UserProfile
+        {
+            Guest = false,
+            HasPuid = true,
+            HasProfile = true,
+            IsMale = true,
+            HasPicture = true
+        };
+
+        Assert.That(profile.GetProfileString(), Is.EqualTo("MY"));
+    }
+
+    [Test]
+    public void GetProfileString_HasPuid_Female_HasPicture_ReturnsFY()
+    {
+        var profile = new UserProfile
+        {
+            Guest = false,
+            HasPuid = true,
+            HasProfile = true,
+            IsFemale = true,
+            HasPicture = true
+        };
+
+        Assert.That(profile.GetProfileString(), Is.EqualTo("FY"));
+    }
+
+    [Test]
+    public void GetProfileString_HasPuid_HasProfile_NoPicture_ReturnsPX()
+    {
+        var profile = new UserProfile
+        {
+            Guest = false,
+            HasPuid = true,
+            HasProfile = true,
+            IsMale = false,
+            IsFemale = false,
+            HasPicture = false
+        };
+
+        Assert.That(profile.GetProfileString(), Is.EqualTo("PX"));
+    }
+
+    [Test]
+    public void GetGenderString_Guest_OverridesHasPuid_ReturnsG()
+    {
+        var profile = new UserProfile
+        {
+            Guest = true,
+            HasPuid = true,
+            HasProfile = true,
+            IsMale = true
+        };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("G"));
+    }
+
+    [Test]
+    public void GetPictureString_Guest_OverridesHasPuid_ReturnsEmpty()
+    {
+        var profile = new UserProfile
+        {
+            Guest = true,
+            HasPuid = true,
+            HasPicture = true
+        };
+
+        Assert.That(profile.GetPictureString(), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void GetGenderString_NoPuid_HasProfile_Male_ReturnsG()
+    {
+        var profile = new UserProfile
+        {
+            Guest = false,
+            HasPuid = false,
+            HasProfile = true,
+            IsMale = true
+        };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("G"),
+            "HasProfile/IsMale must be irrelevant when HasPuid is false");
+    }
+
+    [Test]
+    public void GetProfileString_DeterministicForSameState()
+    {
+        var profile = new UserProfile
+        {
+            Guest = false,
+            HasPuid = true,
+            HasProfile = true,
+            IsMale = true,
+            HasPicture = false
+        };
+
+        var first = profile.GetProfileString();
+        var second = profile.GetProfileString();
+
+        Assert.That(first, Is.EqualTo(second));
+    }
+
+    [Test]
+    public void SetProfileCode_RoundTrip_ReturnsOriginalCode()
+    {
+        for (var code = 0; code <= 15; code++)
+        {
+            var profile = new UserProfile();
+            profile.SetProfileCode(code);
+
+            Assert.That(profile.GetProfileCode(), Is.EqualTo(code),
+                $"Profile code {code} did not round-trip");
+        }
+    }
+}

--- a/Irc.Tests/Objects/User/UserProfileTests.cs
+++ b/Irc.Tests/Objects/User/UserProfileTests.cs
@@ -1,5 +1,7 @@
 using Irc.Enumerations;
+using Irc.Interfaces;
 using Irc.Objects.User;
+using Moq;
 
 namespace Irc.Tests.Objects.User;
 
@@ -7,167 +9,99 @@ namespace Irc.Tests.Objects.User;
 public class UserProfileTests
 {
     [Test]
-    public void GetGenderString_Guest_ReturnsG()
+    public void GetGenderString_NoProfileCode_ReturnsR()
     {
-        var profile = new UserProfile { Guest = true };
-
-        Assert.That(profile.GetGenderString(), Is.EqualTo("G"));
-    }
-
-    [Test]
-    public void GetPictureString_Guest_ReturnsEmpty()
-    {
-        var profile = new UserProfile { Guest = true };
-
-        Assert.That(profile.GetPictureString(), Is.EqualTo(string.Empty));
-    }
-
-    [Test]
-    public void GetGenderString_NonGuest_NoPuid_ReturnsG()
-    {
-        var profile = new UserProfile { Guest = false, HasPuid = false };
-
-        Assert.That(profile.GetGenderString(), Is.EqualTo("G"));
-    }
-
-    [Test]
-    public void GetPictureString_NonGuest_NoPuid_ReturnsEmpty()
-    {
-        var profile = new UserProfile { Guest = false, HasPuid = false };
-
-        Assert.That(profile.GetPictureString(), Is.EqualTo(string.Empty));
-    }
-
-    [Test]
-    public void ToString_NonGuest_NoPuid_NotRegistered_EndsWithGO()
-    {
-        var profile = new UserProfile
-        {
-            Guest = false,
-            HasPuid = false,
-            Registered = false,
-            Away = false,
-            Level = EnumUserAccessLevel.None
-        };
-
-        var result = profile.ToString();
-
-        Assert.That(result, Does.EndWith("GO"),
-            $"Expected profile string to end with 'GO' for a no-PUID non-guest user; got '{result}'");
-    }
-
-    [Test]
-    public void GetGenderString_HasPuid_NoProfile_ReturnsR()
-    {
-        var profile = new UserProfile { Guest = false, HasPuid = true, HasProfile = false };
+        var profile = new UserProfile { HasProfile = false };
 
         Assert.That(profile.GetGenderString(), Is.EqualTo("R"));
     }
 
     [Test]
-    public void GetProfileString_HasPuid_Male_HasPicture_ReturnsMY()
+    public void GetGenderString_HasProfile_NoGender_ReturnsP()
     {
-        var profile = new UserProfile
-        {
-            Guest = false,
-            HasPuid = true,
-            HasProfile = true,
-            IsMale = true,
-            HasPicture = true
-        };
+        var profile = new UserProfile { HasProfile = true };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("P"));
+    }
+
+    [Test]
+    public void GetGenderString_Male_ReturnsM()
+    {
+        var profile = new UserProfile { HasProfile = true, IsMale = true };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("M"));
+    }
+
+    [Test]
+    public void GetGenderString_Female_ReturnsF()
+    {
+        var profile = new UserProfile { HasProfile = true, IsFemale = true };
+
+        Assert.That(profile.GetGenderString(), Is.EqualTo("F"));
+    }
+
+    [Test]
+    public void GetPictureString_HasPicture_ReturnsY()
+    {
+        var profile = new UserProfile { HasPicture = true };
+
+        Assert.That(profile.GetPictureString(), Is.EqualTo("Y"));
+    }
+
+    [Test]
+    public void GetPictureString_NoPicture_ReturnsX()
+    {
+        var profile = new UserProfile { HasPicture = false };
+
+        Assert.That(profile.GetPictureString(), Is.EqualTo("X"));
+    }
+
+    [Test]
+    public void GetProfileString_Male_HasPicture_ReturnsMY()
+    {
+        var profile = new UserProfile { HasProfile = true, IsMale = true, HasPicture = true };
 
         Assert.That(profile.GetProfileString(), Is.EqualTo("MY"));
     }
 
     [Test]
-    public void GetProfileString_HasPuid_Female_HasPicture_ReturnsFY()
+    public void GetProfileString_Female_HasPicture_ReturnsFY()
     {
-        var profile = new UserProfile
-        {
-            Guest = false,
-            HasPuid = true,
-            HasProfile = true,
-            IsFemale = true,
-            HasPicture = true
-        };
+        var profile = new UserProfile { HasProfile = true, IsFemale = true, HasPicture = true };
 
         Assert.That(profile.GetProfileString(), Is.EqualTo("FY"));
     }
 
     [Test]
-    public void GetProfileString_HasPuid_HasProfile_NoPicture_ReturnsPX()
+    public void GetProfileString_HasProfile_NoPicture_ReturnsPX()
     {
-        var profile = new UserProfile
-        {
-            Guest = false,
-            HasPuid = true,
-            HasProfile = true,
-            IsMale = false,
-            IsFemale = false,
-            HasPicture = false
-        };
+        var profile = new UserProfile { HasProfile = true, HasPicture = false };
 
         Assert.That(profile.GetProfileString(), Is.EqualTo("PX"));
     }
 
     [Test]
-    public void GetGenderString_Guest_OverridesHasPuid_ReturnsG()
+    public void GetProfileString_NoProfileCode_ReturnsRX()
     {
-        var profile = new UserProfile
-        {
-            Guest = true,
-            HasPuid = true,
-            HasProfile = true,
-            IsMale = true
-        };
+        var profile = new UserProfile { HasProfile = false, HasPicture = false };
 
-        Assert.That(profile.GetGenderString(), Is.EqualTo("G"));
+        Assert.That(profile.GetProfileString(), Is.EqualTo("RX"));
     }
 
     [Test]
-    public void GetPictureString_Guest_OverridesHasPuid_ReturnsEmpty()
+    public void GetRegisteredString_Registered_ReturnsB()
     {
-        var profile = new UserProfile
-        {
-            Guest = true,
-            HasPuid = true,
-            HasPicture = true
-        };
+        var profile = new UserProfile { Registered = true };
 
-        Assert.That(profile.GetPictureString(), Is.EqualTo(string.Empty));
+        Assert.That(profile.GetRegisteredString(), Is.EqualTo("B"));
     }
 
     [Test]
-    public void GetGenderString_NoPuid_HasProfile_Male_ReturnsG()
+    public void GetRegisteredString_NotRegistered_ReturnsO()
     {
-        var profile = new UserProfile
-        {
-            Guest = false,
-            HasPuid = false,
-            HasProfile = true,
-            IsMale = true
-        };
+        var profile = new UserProfile { Registered = false };
 
-        Assert.That(profile.GetGenderString(), Is.EqualTo("G"),
-            "HasProfile/IsMale must be irrelevant when HasPuid is false");
-    }
-
-    [Test]
-    public void GetProfileString_DeterministicForSameState()
-    {
-        var profile = new UserProfile
-        {
-            Guest = false,
-            HasPuid = true,
-            HasProfile = true,
-            IsMale = true,
-            HasPicture = false
-        };
-
-        var first = profile.GetProfileString();
-        var second = profile.GetProfileString();
-
-        Assert.That(first, Is.EqualTo(second));
+        Assert.That(profile.GetRegisteredString(), Is.EqualTo("O"));
     }
 
     [Test]
@@ -181,5 +115,97 @@ public class UserProfileTests
             Assert.That(profile.GetProfileCode(), Is.EqualTo(code),
                 $"Profile code {code} did not round-trip");
         }
+    }
+}
+
+[TestFixture]
+public class UserFormattedProfileTests
+{
+    [Test]
+    public void NoProfile_IsGuest_AndIrc8FlagIsGO()
+    {
+        var user = CreateUser();
+
+        Assert.That(user.IsGuest(), Is.True,
+            "A user with no Passport profile is a guest");
+        Assert.That(user.GetFormattedProfile(EnumProtocolType.IRC8), Is.EqualTo("H,U,GO"),
+            "No profile renders gender 'G' so clients hide View Profile");
+    }
+
+    [Test]
+    public void PassportProfile_NotGuest_AndIrc8FlagIsRXO()
+    {
+        var user = CreateUser();
+        user.AssignPassportProfile();
+
+        Assert.That(user.IsGuest(), Is.False,
+            "A user with a Passport profile is not a guest");
+        Assert.That(user.GetFormattedProfile(EnumProtocolType.IRC8), Is.EqualTo("H,U,RXO"),
+            "A passport user with no profile code reports 'RX', distinct from the no-profile 'G'");
+    }
+
+    [Test]
+    public void PassportProfile_MaleWithPicture_Irc8_ReportsMYO()
+    {
+        var user = CreateUser();
+        user.AssignPassportProfile();
+        user.GetProfile()!.SetProfileCode(11);
+
+        Assert.That(user.GetFormattedProfile(EnumProtocolType.IRC8), Is.EqualTo("H,U,MYO"));
+    }
+
+    [Test]
+    public void NoProfile_Irc5_GenderOnly()
+    {
+        var user = CreateUser();
+
+        Assert.That(user.GetFormattedProfile(EnumProtocolType.IRC5), Is.EqualTo("H,U,G"));
+    }
+
+    [Test]
+    public void NoProfile_Irc7_GenderAndEmptyPicture()
+    {
+        var user = CreateUser();
+
+        Assert.That(user.GetFormattedProfile(EnumProtocolType.IRC7), Is.EqualTo("H,U,G"));
+    }
+
+    [Test]
+    public void PassportProfile_MaleWithPicture_Irc7_ReportsMY()
+    {
+        var user = CreateUser();
+        user.AssignPassportProfile();
+        user.GetProfile()!.SetProfileCode(11);
+
+        Assert.That(user.GetFormattedProfile(EnumProtocolType.IRC7), Is.EqualTo("H,U,MY"));
+    }
+
+    [Test]
+    public void AwayUser_NoProfile_Irc8_AwayCharIsG()
+    {
+        var user = CreateUser();
+        user.Away = true;
+
+        Assert.That(user.GetFormattedProfile(EnumProtocolType.IRC8), Is.EqualTo("G,U,GO"));
+    }
+
+    private static Irc.Objects.User.User CreateUser()
+    {
+        var mockConnection = new Mock<IConnection>();
+        var mockProtocol = new Mock<IProtocol>();
+        var mockDataRegulator = new Mock<IDataRegulator>();
+        var mockFloodProtectionProfile = new Mock<IFloodProtectionProfile>();
+        var mockServer = new Mock<IServer>();
+
+        mockConnection.Setup(x => x.GetIp()).Returns("127.0.0.1");
+        mockServer.Setup(s => s.DisableGuestMode).Returns(false);
+
+        return new Irc.Objects.User.User(
+            mockConnection.Object,
+            mockProtocol.Object,
+            mockDataRegulator.Object,
+            mockFloodProtectionProfile.Object,
+            mockServer.Object,
+            _ => new Mock<ISaslHandler>().Object);
     }
 }

--- a/Irc/Commands/Auth.cs
+++ b/Irc/Commands/Auth.cs
@@ -5,6 +5,7 @@ using Irc.Enumerations;
 using Irc.Helpers;
 using Irc.Interfaces;
 using Irc.Objects.Server;
+using Irc.Objects.User;
 using Irc.Security.Credentials;
 
 public class Auth : Command, ICommand
@@ -226,6 +227,7 @@ public class Auth : Command, ICommand
         chatFrame.User.SetGuest(credentials.Guest);
         chatFrame.User.SetLevel(credentials.GetLevel());
 
+        ((User)chatFrame.User).GetProfile().HasPuid = !chatFrame.User.IsGuest() && saslHandler.RequiresPassport;
         // TODO: find another way to work in Utf8 nicknames
         if (chatFrame.User.GetLevel() >= EnumUserAccessLevel.Guide) chatFrame.User.Utf8 = true;
 

--- a/Irc/Commands/Auth.cs
+++ b/Irc/Commands/Auth.cs
@@ -5,7 +5,6 @@ using Irc.Enumerations;
 using Irc.Helpers;
 using Irc.Interfaces;
 using Irc.Objects.Server;
-using Irc.Objects.User;
 using Irc.Security.Credentials;
 
 public class Auth : Command, ICommand
@@ -224,10 +223,10 @@ public class Auth : Command, ICommand
         if (credentials.Guest && string.IsNullOrWhiteSpace(chatFrame.User.GetAddress().RealName))
             userAddress.RealName = string.Empty;
 
-        chatFrame.User.SetGuest(credentials.Guest);
         chatFrame.User.SetLevel(credentials.GetLevel());
 
-        ((User)chatFrame.User).GetProfile().HasPuid = !chatFrame.User.IsGuest() && saslHandler.RequiresPassport;
+        if (!credentials.Guest && saslHandler.RequiresPassport)
+            chatFrame.User.AssignPassportProfile();
         // TODO: find another way to work in Utf8 nicknames
         if (chatFrame.User.GetLevel() >= EnumUserAccessLevel.Guide) chatFrame.User.Utf8 = true;
 

--- a/Irc/Commands/Auth.cs
+++ b/Irc/Commands/Auth.cs
@@ -219,7 +219,7 @@ public class Auth : Command, ICommand
         userAddress.Host = credentials.GetDomain();
         userAddress.Server = chatFrame.Server.Name;
         var nickname = credentials.GetNickname();
-        if (!string.IsNullOrWhiteSpace(nickname)) chatFrame.User.Name = credentials.GetNickname();
+        if (!string.IsNullOrWhiteSpace(nickname)) chatFrame.User.Name = $"{credentials.Prefix}{credentials.GetNickname()}";
         if (credentials.Guest && string.IsNullOrWhiteSpace(chatFrame.User.GetAddress().RealName))
             userAddress.RealName = string.Empty;
 
@@ -232,7 +232,5 @@ public class Auth : Command, ICommand
 
         // Send reply
         chatFrame.User.Send(Raws.RPL_AUTH_SUCCESS(packageName, $"{user}@{domain}", 0));
-
-        return;
     }
 }

--- a/Irc/Commands/Nick.cs
+++ b/Irc/Commands/Nick.cs
@@ -29,27 +29,51 @@ public class Nick : Command, ICommand
     }
 
     public static bool ValidateNickname(string nickname, bool guest = false, bool oper = false, bool preAuth = false,
-        bool preReg = false, bool isDs = false)
+        bool preReg = false, bool isDs = false, string? requiredPrefix = null)
     {
         var mask = Resources.PostAuthNicknameMask;
 
         if (preAuth) mask = Resources.PreAuthNicknameMask;
         else if (oper) mask = Resources.PostAuthOperNicknameMask;
-        else if (guest) mask = Resources.PostAuthGuestNicknameMask;
 
         if (isDs) mask = Resources.DsNickname;
 
         var isInLength = nickname.Length <= Resources.MaxFieldLen;
         var isMatch = RegularExpressions.Match(mask, nickname, true);
-        var isValid = isInLength && isMatch;
+        var isPrefixValid = ValidatePrefix(nickname, requiredPrefix);
+        var isValid = isInLength && isMatch && isPrefixValid;
         return isValid;
+    }
+
+    /// <summary>
+    /// Ensures the nickname begins with the required prefix character obtained from the
+    /// authenticated user's credentials (DefaultPermissions.json prefix). When no prefix is
+    /// required (empty/null), the nickname passes this check.
+    /// </summary>
+    private static bool ValidatePrefix(string nickname, string? requiredPrefix)
+    {
+        if (string.IsNullOrEmpty(requiredPrefix)) return true;
+        return nickname.Length > 0 && nickname[0] == requiredPrefix[0];
+    }
+
+    /// <summary>
+    /// Resolves the required nickname prefix for a user. Uses the prefix from the user's
+    /// SASL credentials when authenticated; otherwise falls back to the global ANON prefix
+    /// from DefaultPermissions.json (or a built-in default when ANON is not configured).
+    /// </summary>
+    public static string ResolveRequiredPrefix(IUser user)
+    {
+        var credentials = user.GetSspiHandler()?.GetCredentials();
+        return credentials?.Prefix ?? Security.DefaultPermissions.AnonPrefix;
     }
 
     public static bool HandlePreauthNicknameChange(IChatFrame chatFrame)
     {
         var nickname = chatFrame.ChatMessage.Parameters.First();
         // UTF8 / Guest / Normal / Admin/Sysop/Guide OK
-        var isValid = ValidateNickname(nickname, preAuth: true, isDs: chatFrame.Server.IsDirectoryServer); 
+        var requiredPrefix = ResolveRequiredPrefix(chatFrame.User);
+        var isValid = ValidateNickname(nickname, preAuth: true, isDs: chatFrame.Server.IsDirectoryServer,
+            requiredPrefix: requiredPrefix); 
         if (!isValid)
         {
             chatFrame.User.Send(Raws.IRCX_ERR_ERRONEOUSNICK_432(chatFrame.Server, chatFrame.User, nickname));
@@ -66,7 +90,8 @@ public class Nick : Command, ICommand
         var guest = chatFrame.User.IsGuest();
         var oper = chatFrame.User.GetLevel() >= EnumUserAccessLevel.Guide;
 
-        if (!ValidateNickname(nickname, guest, oper, false, true, isDs: chatFrame.Server.IsDirectoryServer))
+        if (!ValidateNickname(nickname, guest, oper, false, true, isDs: chatFrame.Server.IsDirectoryServer,
+                requiredPrefix: ResolveRequiredPrefix(chatFrame.User)))
         {
             chatFrame.User.Send(Raws.IRCX_ERR_ERRONEOUSNICK_432(chatFrame.Server, chatFrame.User, nickname));
             return false;
@@ -97,7 +122,8 @@ public class Nick : Command, ICommand
                 return false;
             }
 
-        if (!ValidateNickname(nickname, guest, oper, isDs: chatFrame.Server.IsDirectoryServer))
+        if (!ValidateNickname(nickname, guest, oper, isDs: chatFrame.Server.IsDirectoryServer,
+                requiredPrefix: ResolveRequiredPrefix(chatFrame.User)))
         {
             chatFrame.User.Send(Raws.IRCX_ERR_ERRONEOUSNICK_432(chatFrame.Server, chatFrame.User, nickname));
             return false;

--- a/Irc/Commands/Privmsg.cs
+++ b/Irc/Commands/Privmsg.cs
@@ -48,7 +48,7 @@ public class Privmsg : Command, ICommand
 
                 // Cannot send as a non-subscriber
                 if (user.GetLevel() < EnumUserAccessLevel.Guide &&
-                    !user.GetProfile().IsSubscriber &&
+                    !(user.GetProfile()?.IsSubscriber ?? false) &&
                     subscriberOnly.ModeValue
                    )
                 {

--- a/Irc/Commands/Prop.cs
+++ b/Irc/Commands/Prop.cs
@@ -176,9 +176,17 @@ public class Prop : Command, ICommand
     public void SendProps(IServer server, IUser user, IChatObject targetObject, List<IPropRule> props)
     {
         var propsSent = 0;
+        var emptyProp = false;
         foreach (var prop in props)
         {
-            if (prop.EvaluateGet((IChatObject)user, targetObject) == EnumIrcError.ERR_NOPERMS)
+            var result = prop.EvaluateGet((IChatObject)user, targetObject);
+            if (result == EnumIrcError.NO_VALUE)
+            {
+                emptyProp = true;
+                continue;
+            }
+
+            if (result == EnumIrcError.ERR_NOPERMS)
             {
                 if (props.Count == 1) user.Send(Raws.IRCX_ERR_SECURITY_908(server, user));
                 continue;
@@ -206,7 +214,7 @@ public class Prop : Command, ICommand
             propsSent++;
         }
 
-        if (propsSent > 0) user.Send(Raws.IRCX_RPL_PROPEND_819(server, user, targetObject));
+        if (propsSent > 0 || emptyProp) user.Send(Raws.IRCX_RPL_PROPEND_819(server, user, targetObject));
     }
 
     public void SendProp(IServer server, IUser user, IChatObject targetObject, string propName,

--- a/Irc/Constants/Resources.cs
+++ b/Irc/Constants/Resources.cs
@@ -372,14 +372,12 @@ public static class Resources
     public static string PreAuthNicknameMask = @"(^[>'][\x41-\xFF\-0-9]+$)|(^[\x41-\xFF][\x41-\xFF\-0-9]+$)";
     public static string PostAuthNicknameMask = @"^(?!(Sysop)|(Admin)|(Guide))[\x41-\xFF][\x41-\xFF\-0-9]+$";
     public static string PostAuthOperNicknameMask = @"^'?[\x41-\xFF][\x41-\xFF\-0-9]*$";
-    public static string PostAuthGuestNicknameMask = @"^>[\x41-\xFF][\x41-\xFF\-0-9]*$";
 
     public static string StandardIRC = @"[(\x00-\x2C)(\x2E-\x2F)(\x3A-\x40)]{1}|\\N|\\R|\\0|\\T";
     public static string GenericProps = @"[\x20-\x7F]{0,31}";
     public static string JoinPartProp = @"[\x00]{1}";
     public static string IrcChannelRegex = @"#[\x21-\x2B,\x2D-\xFF]{1,200}";
     public static string IrcxChannelRegex = @"^%#[\x21-\x2B\x2D-\xFF]{1,200}$";
-    public static string GuestNicknameMask = @"^>(?!(Sysop)|(Admin)|(Guide))[\x41-\xFF\-0-9]+$";
     public static string NicknameMask = @"^(?!(Sysop)|(Admin)|(Guide))[\x41-\xFF][\x41-\xFF\-0-9]*$";
     public static string DsNickname = @"[\x41-\xFF\-0-9]+$";
     public static string StandardUtf8Nickname = @"^'?[\x41-\xFF][\x41-\xFF\-0-9]*$";

--- a/Irc/Enumerations/EnumAccessResult.cs
+++ b/Irc/Enumerations/EnumAccessResult.cs
@@ -3,6 +3,7 @@
 public enum EnumIrcError
 {
     OK = -1,
+    NO_VALUE = -2,
     NONE = 0,
     ERR_ALREADYINCHANNEL = 1,
     ERR_NOSUCHNICK = 401,

--- a/Irc/Interfaces/IUser.cs
+++ b/Irc/Interfaces/IUser.cs
@@ -21,7 +21,6 @@ public interface IUser
     bool Utf8 { get; set; }
     IChatFrame GetNextFrame();
     void ChangeNickname(string newNick, bool utf8Prefix);
-    void SetGuest(bool guest);
     void SetAway(IServer server, IUser user, string message);
     void SetBack(IServer server, IUser user);
     void SetLevel(EnumUserAccessLevel level);
@@ -61,4 +60,6 @@ public interface IUser
     Queue<ModeOperation> GetModeOperations();
     ISaslHandler? GetSspiHandler();
     ISaslHandler InitializeSspiHandler(bool passport);
+    UserProfile? GetProfile();
+    void AssignPassportProfile();
 }

--- a/Irc/Objects/Server/Server.cs
+++ b/Irc/Objects/Server/Server.cs
@@ -499,12 +499,16 @@ public class Server : ChatObject, IServer
             var subscribedString =
                 Passport.ValidateSubscriberInfo(value, issuedAt.Value);
             int.TryParse(subscribedString, out var subscribed);
-            if ((subscribed & 1) == 1) ((User.User)user).GetProfile().Registered = true;
+            if ((subscribed & 1) == 1)
+            {
+                var profile = user.GetProfile();
+                if (profile != null) profile.Registered = true;
+            }
         }
         else if (name == Resources.UserPropMsnProfile && user.IsAuthenticated() && !user.IsRegistered())
         {
             int.TryParse(value, out var profileCode);
-            ((User.User)user).GetProfile().SetProfileCode(profileCode);
+            user.GetProfile()?.SetProfileCode(profileCode);
         }
         else if (name == Resources.UserPropRole && user.IsAuthenticated())
         {

--- a/Irc/Objects/User/User.cs
+++ b/Irc/Objects/User/User.cs
@@ -25,7 +25,6 @@ public class User : ChatObject, IUser
     public override IAccessList Access => base.Access;
 
     private long _commandSequence;
-    private bool _guest;
     private EnumUserAccessLevel _level;
     private IProtocol _protocol;
     private bool _registered;
@@ -66,7 +65,7 @@ public class User : ChatObject, IUser
         UserAddress.SetIp(connection.GetIp());
     }
 
-    private UserProfile UserProfile { get; } = new();
+    private UserProfile? UserProfile { get; set; }
 
     public override EnumUserAccessLevel Level => GetLevel();
 
@@ -208,14 +207,8 @@ public class User : ChatObject, IUser
 
     public bool IsGuest()
     {
-        return _guest;
-    }
-
-    public virtual void SetGuest(bool guest)
-    {
-        if (Server.DisableGuestMode) return;
-        UserProfile.Guest = guest;
-        _guest = guest;
+        if (Server.DisableGuestMode) return false;
+        return UserProfile == null;
     }
 
     public void SetLevel(EnumUserAccessLevel level)
@@ -256,7 +249,6 @@ public class User : ChatObject, IUser
     public virtual void SetAway(IServer server, IUser user, string message)
     {
         user.Away = true;
-        UserProfile.Away = true;
         foreach (var channelPair in user.GetChannels())
         {
             var channel = channelPair.Key;
@@ -269,7 +261,6 @@ public class User : ChatObject, IUser
     public virtual void SetBack(IServer server, IUser user)
     {
         user.Away = false;
-        UserProfile.Away = false;
         foreach (var channelPair in user.GetChannels())
         {
             var channel = channelPair.Key;
@@ -284,7 +275,6 @@ public class User : ChatObject, IUser
         Modes.Admin.ModeValue = true;
         Modes.Admin.DispatchModeChange(this, this, true, string.Empty);
         _level = EnumUserAccessLevel.Administrator;
-        UserProfile.Level = EnumUserAccessLevel.Administrator;
         Send(Raws.IRCX_RPL_YOUREADMIN_386(Server, this));
     }
 
@@ -293,7 +283,6 @@ public class User : ChatObject, IUser
         Modes.Oper.ModeValue = true;
         Modes.Oper.DispatchModeChange(this, this, true, string.Empty);
         _level = EnumUserAccessLevel.Sysop;
-        UserProfile.Level = EnumUserAccessLevel.Sysop;
         Send(Raws.IRCX_RPL_YOUREOPER_381(Server, this));
     }
 
@@ -302,7 +291,6 @@ public class User : ChatObject, IUser
         Modes.Oper.ModeValue = true;
         Modes.Oper.DispatchModeChange(this, this, true, string.Empty);
         _level = EnumUserAccessLevel.Guide;
-        UserProfile.Level = EnumUserAccessLevel.Guide;
         Send(Raws.IRCX_RPL_YOUREGUIDE_629(Server, this));
     }
 
@@ -416,9 +404,48 @@ public class User : ChatObject, IUser
         };
     }
 
-    public UserProfile GetProfile()
+    public UserProfile? GetProfile()
     {
         return UserProfile;
+    }
+
+    public void AssignPassportProfile()
+    {
+        UserProfile ??= new UserProfile();
+    }
+
+    public string GetFormattedProfile(EnumProtocolType protocol)
+    {
+        var away = Away ? "G" : "H";
+        var mode = GetModeCharacter();
+        var gender = UserProfile?.GetGenderString() ?? "G";
+
+        if (protocol == EnumProtocolType.IRC5) return $"{away},{mode},{gender}";
+
+        var picture = UserProfile?.GetPictureString() ?? string.Empty;
+
+        if (protocol == EnumProtocolType.IRC8)
+        {
+            var registered = UserProfile?.GetRegisteredString() ?? "O";
+            return $"{away},{mode},{gender}{picture}{registered}";
+        }
+
+        return $"{away},{mode},{gender}{picture}";
+    }
+
+    private string GetModeCharacter()
+    {
+        switch (GetLevel())
+        {
+            case EnumUserAccessLevel.Administrator:
+                return "A";
+            case EnumUserAccessLevel.Sysop:
+                return "S";
+            case EnumUserAccessLevel.Guide:
+                return "G";
+            default:
+                return "U";
+        }
     }
 
     public override bool CanBeModifiedBy(IChatObject source)

--- a/Irc/Objects/User/UserProfile.cs
+++ b/Irc/Objects/User/UserProfile.cs
@@ -52,6 +52,7 @@ public class UserProfile
     public bool IsFemale { get; set; }
     public bool HasPicture { get; set; }
     public bool IsSubscriber { get; set; }
+    public bool HasPuid { get; set; }
 
     public int GetProfileCode()
     {
@@ -81,7 +82,7 @@ public class UserProfile
 
     public string GetPictureString()
     {
-        return Guest ? "" : HasPicture ? "Y" : "X";
+        return (Guest || !HasPuid) ? "" : HasPicture ? "Y" : "X";
     }
 
     public string GetProfileString()
@@ -114,7 +115,7 @@ public class UserProfile
 
     public string GetGenderString()
     {
-        if (Guest) return "G";
+        if (Guest || !HasPuid) return "G";
         if (!HasProfile) return "R";
 
         return !IsMale && !IsFemale ? "P" : IsMale ? "M" : "F";

--- a/Irc/Objects/User/UserProfile.cs
+++ b/Irc/Objects/User/UserProfile.cs
@@ -1,6 +1,4 @@
-﻿using Irc.Enumerations;
-
-namespace Irc.Objects.User;
+﻿namespace Irc.Objects.User;
 /*
 // TODO: MSNPROFILE
 (Code) - (MSNPROFILE) - (Description)
@@ -43,16 +41,12 @@ IRC8 H,A,GO is correct as well as
 
 public class UserProfile
 {
-    public EnumUserAccessLevel Level { get; set; }
-    public bool Away { get; set; }
-    public bool Guest { get; set; }
     public bool Registered { get; set; }
     public bool HasProfile { get; set; }
     public bool IsMale { get; set; }
     public bool IsFemale { get; set; }
     public bool HasPicture { get; set; }
     public bool IsSubscriber { get; set; }
-    public bool HasPuid { get; set; }
 
     public int GetProfileCode()
     {
@@ -70,11 +64,6 @@ public class UserProfile
         HasPicture = Convert.ToBoolean(code & 8);
     }
 
-    public string GetAwayString()
-    {
-        return Away ? "G" : "H";
-    }
-
     public string GetRegisteredString()
     {
         return Registered ? "B" : "O";
@@ -82,7 +71,7 @@ public class UserProfile
 
     public string GetPictureString()
     {
-        return (Guest || !HasPuid) ? "" : HasPicture ? "Y" : "X";
+        return HasPicture ? "Y" : "X";
     }
 
     public string GetProfileString()
@@ -90,49 +79,10 @@ public class UserProfile
         return $"{GetGenderString()}{GetPictureString()}";
     }
 
-    public string GetModeString()
-    {
-        switch (Level)
-        {
-            case EnumUserAccessLevel.Administrator:
-            {
-                return "A";
-            }
-            case EnumUserAccessLevel.Sysop:
-            {
-                return "S";
-            }
-            case EnumUserAccessLevel.Guide:
-            {
-                return "G";
-            }
-            default:
-            {
-                return "U";
-            }
-        }
-    }
-
     public string GetGenderString()
     {
-        if (Guest || !HasPuid) return "G";
         if (!HasProfile) return "R";
 
         return !IsMale && !IsFemale ? "P" : IsMale ? "M" : "F";
-    }
-
-    public string Irc5_ToString()
-    {
-        return $"{GetAwayString()},{GetModeString()},{GetGenderString()}";
-    }
-
-    public string Irc7_ToString()
-    {
-        return $"{GetAwayString()},{GetModeString()},{GetProfileString()}";
-    }
-
-    public override string ToString()
-    {
-        return $"{GetAwayString()},{GetModeString()},{GetProfileString()}{GetRegisteredString()}";
     }
 }

--- a/Irc/Objects/User/UserProps.cs
+++ b/Irc/Objects/User/UserProps.cs
@@ -23,6 +23,7 @@ public class PropProfile : PropRule
         if (int.TryParse(propValue, out var result))
         {
             var profile = user.GetProfile();
+            if (profile == null) return EnumIrcError.OK;
             if (profile.HasProfile)
             {
                 user.Send(Raws.IRCX_ERR_ALREADYREGISTERED_462(user.Server, user));
@@ -69,11 +70,7 @@ public class PropPuid : PropRule, IPropRule
         if (!sharedChannel)
             return EnumIrcError.ERR_NOPERMS;
 
-        if (targetUser.IsGuest())
-            return EnumIrcError.NO_VALUE;
-
-        var sspiHandler = targetUser.GetSspiHandler();
-        if (sspiHandler == null || !sspiHandler.RequiresPassport)
+        if (targetUser.GetProfile() == null)
             return EnumIrcError.NO_VALUE;
 
         return EnumIrcError.OK;

--- a/Irc/Objects/User/UserProps.cs
+++ b/Irc/Objects/User/UserProps.cs
@@ -65,23 +65,17 @@ public class PropPuid : PropRule, IPropRule
         if (source is not IUser sourceUser || target is not IUser targetUser)
             return EnumIrcError.ERR_NOPERMS;
 
-        // If target is a guest, deny access
-        if (targetUser.IsGuest())
-            return EnumIrcError.ERR_NOPERMS;
-
-        // If the target is not passport authenticated, deny access
-        var sspiHandler = targetUser.GetSspiHandler();
-        if (sspiHandler == null || !sspiHandler.RequiresPassport)
-            return EnumIrcError.ERR_NOPERMS;
-
-        // If source and target are not on the same channel, deny access
-        var sharedChannel = sourceUser.GetChannels().Keys
-            .Any(channel => targetUser.IsOn(channel));
-
+        var sharedChannel = sourceUser.GetChannels().Keys.Any(channel => targetUser.IsOn(channel));
         if (!sharedChannel)
             return EnumIrcError.ERR_NOPERMS;
 
-        // GetValue will return the PUID from the credentials
+        if (targetUser.IsGuest())
+            return EnumIrcError.NO_VALUE;
+
+        var sspiHandler = targetUser.GetSspiHandler();
+        if (sspiHandler == null || !sspiHandler.RequiresPassport)
+            return EnumIrcError.NO_VALUE;
+
         return EnumIrcError.OK;
     }
 

--- a/Irc/Protocols/Irc5.cs
+++ b/Irc/Protocols/Irc5.cs
@@ -11,7 +11,7 @@ internal class Irc5 : Irc4
         var modeChar = string.Empty;
         if (member.HasModes()) modeChar += member.Owner.ModeValue ? '.' : member.Operator.ModeValue ? '@' : '+';
 
-        var profile = ((User)member.GetUser()).GetProfile().Irc5_ToString();
+        var profile = ((User)member.GetUser()).GetFormattedProfile(EnumProtocolType.IRC5);
         return $"{profile},{modeChar}{member.GetUser().GetAddress().Nickname}";
     }
 
@@ -22,6 +22,6 @@ internal class Irc5 : Irc4
 
     public override string GetFormat(IUser user)
     {
-        return ((User)user).GetProfile().Irc5_ToString();
+        return ((User)user).GetFormattedProfile(EnumProtocolType.IRC5);
     }
 }

--- a/Irc/Protocols/Irc7.cs
+++ b/Irc/Protocols/Irc7.cs
@@ -11,7 +11,7 @@ internal class Irc7 : Irc6
         var modeChar = string.Empty;
         if (member.HasModes()) modeChar += member.Owner.ModeValue ? '.' : member.Operator.ModeValue ? '@' : '+';
 
-        var profile = ((User)member.GetUser()).GetProfile().Irc7_ToString();
+        var profile = ((User)member.GetUser()).GetFormattedProfile(EnumProtocolType.IRC7);
         return $"{profile},{modeChar}{member.GetUser().GetAddress().Nickname}";
     }
 
@@ -22,6 +22,6 @@ internal class Irc7 : Irc6
 
     public override string GetFormat(IUser user)
     {
-        return ((User)user).GetProfile().Irc7_ToString();
+        return ((User)user).GetFormattedProfile(EnumProtocolType.IRC7);
     }
 }

--- a/Irc/Protocols/Irc8.cs
+++ b/Irc/Protocols/Irc8.cs
@@ -11,7 +11,7 @@ internal class Irc8 : Irc7
         var modeChar = string.Empty;
         if (member.HasModes()) modeChar += member.Owner.ModeValue ? '.' : member.Operator.ModeValue ? '@' : '+';
 
-        var profile = ((User)member.GetUser()).GetProfile().ToString();
+        var profile = ((User)member.GetUser()).GetFormattedProfile(EnumProtocolType.IRC8);
         return $"{profile},{modeChar}{member.GetUser().GetAddress().Nickname}";
     }
 
@@ -22,6 +22,6 @@ internal class Irc8 : Irc7
 
     public override string GetFormat(IUser user)
     {
-        return ((User)user).GetProfile().ToString();
+        return ((User)user).GetFormattedProfile(EnumProtocolType.IRC8);
     }
 }

--- a/Irc/Register.cs
+++ b/Irc/Register.cs
@@ -193,8 +193,10 @@ public static class Register
 
         if (!authenticating && !registered && hasNickname)
         {
+            var requiredPrefix = Nick.ResolveRequiredPrefix(user);
             var isNicknameValid =
-                Nick.ValidateNickname(nickname, guest, oper, authenticating, isDs: chatFrame.Server.IsDirectoryServer);
+                Nick.ValidateNickname(nickname, guest, oper, authenticating, isDs: chatFrame.Server.IsDirectoryServer,
+                    requiredPrefix: server.IsDirectoryServer ? string.Empty : requiredPrefix);
 
             if (!isNicknameValid)
             {

--- a/Irc/Security/DefaultPermissions.cs
+++ b/Irc/Security/DefaultPermissions.cs
@@ -1,0 +1,45 @@
+namespace Irc.Security;
+
+/// <summary>
+/// Global, read-only holder for the permission profiles loaded from DefaultPermissions.json.
+/// Populated once at startup so validation logic (e.g. nickname prefix checks) can access
+/// the profiles without repeatedly loading/parsing the file.
+/// </summary>
+public static class DefaultPermissions
+{
+    /// <summary>Key used for the anonymous fallback profile in DefaultPermissions.json.</summary>
+    public const string AnonProfileKey = "ANON";
+
+    /// <summary>
+    /// Fallback prefix used when the ANON profile is not present in DefaultPermissions.json.
+    /// Anonymous users have no nickname prefix by default.
+    /// </summary>
+    private const string DefaultAnonPrefix = "";
+
+    private static Dictionary<string, PermissionProfile> _profiles =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public static IReadOnlyDictionary<string, PermissionProfile> Profiles => _profiles;
+
+    /// <summary>
+    /// Registers the loaded permission profiles globally. Should be called once at startup.
+    /// </summary>
+    public static void Initialize(Dictionary<string, PermissionProfile>? profiles)
+    {
+        _profiles = profiles != null
+            ? new Dictionary<string, PermissionProfile>(profiles, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, PermissionProfile>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static PermissionProfile? GetProfile(string key)
+    {
+        return _profiles.TryGetValue(key, out var profile) ? profile : null;
+    }
+
+    /// <summary>
+    /// The nickname prefix for anonymous users. Falls back to <see cref="DefaultAnonPrefix"/>
+    /// when the ANON profile is missing from DefaultPermissions.json.
+    /// </summary>
+    public static string AnonPrefix => GetProfile(AnonProfileKey)?.Prefix ?? DefaultAnonPrefix;
+}
+


### PR DESCRIPTION
## Root cause

Two bugs combined to break `PROP <nick> PUID` for non-passport users.

**Bug 1 — wrong reply.** `PropPuid.EvaluateGet` returned `ERR_NOPERMS` for any target with no PUID (guest or non-passport), and `Prop.SendProps` mapped that to a `908 IRCERR_SECURITY` reply. The IRCX draft (`docs/draft-pfenning-irc-extensions-04.txt`) defines the three relevant responses:

```text
818 - IRCRPL_PROPLIST   <object> <property> :<value>   A value in a property list.
819 - IRCRPL_PROPEND    <object> :End of properties    Last message in a property list.
908 - IRCERR_SECURITY   :No permissions to perform command   (a permission denial)
```

An empty property list (a queried property with no value) is a bare `819` with no preceding `818`. Returning `908` for a non-passport user is wrong: `908` signals a permission failure, not an absent value.

**Bug 2 — wrong member flag.** `UserProfile.GetGenderString` returned `R` for any non-guest with no profile, regardless of passport status. The MSN OCX gates its View Profile button and the `PROP <nick> PUID` call on the position-3 character of the member flag (decompile, `band-05.md:109-110`):

```text
Sends PROP <prefix> PUID ... when the target member has the PUID-capable flag
(member+0x28 bit 9) and we are in a room. Feeds the profile-link flow (numeric 818).
```

`G` clears the PUID-capable bit (client hides View Profile and skips `PROP PUID`); `R`/`M`/`F`/`P` set it. A non-passport user getting `R` caused the client to show a View Profile button that always returned `908`.

The reporter observed `PROP Snue PUID` → `908`, expected `819 Snue :End of properties`; and flags `H,U,RXO` (position-3 `R`), expected `H,U,GO`.

## Fix A — `PROP <nick> PUID` returns `819` for no-PUID targets

Gate-first `EvaluateGet`: the shared-channel access check runs before PUID classification so a non-co-member learns nothing about the target's passport state. No-PUID cases return a new sentinel `NO_VALUE` instead of `ERR_NOPERMS`:

```csharp
// Irc/Objects/User/UserProps.cs — PropPuid.EvaluateGet
public override EnumIrcError EvaluateGet(IChatObject source, IChatObject target)
{
    if (source is not IUser sourceUser || target is not IUser targetUser)
        return EnumIrcError.ERR_NOPERMS;

    var sharedChannel = sourceUser.GetChannels().Keys.Any(channel => targetUser.IsOn(channel));
    if (!sharedChannel)
        return EnumIrcError.ERR_NOPERMS;

    if (targetUser.IsGuest())
        return EnumIrcError.NO_VALUE;

    var sspiHandler = targetUser.GetSspiHandler();
    if (sspiHandler == null || !sspiHandler.RequiresPassport)
        return EnumIrcError.NO_VALUE;

    return EnumIrcError.OK;
}
```

`NO_VALUE = -2` is a new sentinel in `EnumIrcError`, never written to the wire:

```csharp
// Irc/Enumerations/EnumAccessResult.cs
OK = -1,
NO_VALUE = -2,
```

`Prop.SendProps` consumes the tri-state and drives the terminator conditionally:

```csharp
// Irc/Commands/Prop.cs — SendProps (excerpt)
var emptyProp = false;
foreach (var prop in props)
{
    var result = prop.EvaluateGet((IChatObject)user, targetObject);
    if (result == EnumIrcError.NO_VALUE) { emptyProp = true; continue; }
    if (result == EnumIrcError.ERR_NOPERMS)
    {
        if (props.Count == 1) user.Send(Raws.IRCX_ERR_SECURITY_908(server, user));
        continue;
    }
    // (unchanged: 818 value send + propsSent++)
}
if (propsSent > 0 || emptyProp) user.Send(Raws.IRCX_RPL_PROPEND_819(server, user, targetObject));
```

| Requester / target | Response |
|---|---|
| No shared channel | `908` only |
| Co-member; guest or non-passport | `819` (empty list) |
| Co-member; has passport | `818 PUID :<puid>` then `819` |

The PUID is the ident field of the passport address (irc7_api#6: `Skyxo!F65301A71DC2246C@MicrosoftPassport`), read via `saslHandler.GetCredentials().Username`.

**Security note (gate-first):** running the shared-channel check before PUID classification prevents cross-channel inference of passport state — a non-co-member always receives `908`.

## Fix B — Member flag emits `G` for no-PUID users

`GetGenderString`/`GetPictureString` now gate on `HasPuid` (before: only `Guest` was checked, so a non-passport user fell through to `R`):

```csharp
// Irc/Objects/User/UserProfile.cs
public string GetGenderString()
{
    if (Guest || !HasPuid) return "G";
    if (!HasProfile) return "R";
    return !IsMale && !IsFemale ? "P" : IsMale ? "M" : "F";
}

public string GetPictureString()
{
    return (Guest || !HasPuid) ? "" : HasPicture ? "Y" : "X";
}
```

`HasPuid` is set once in `Auth.AuthenticateUser`, using the same predicate `EvaluateGet` evaluates at query time, so flag and reply cannot disagree:

```csharp
// Irc/Commands/Auth.cs — AuthenticateUser (after SetGuest/SetLevel)
((User)chatFrame.User).GetProfile().HasPuid =
    !chatFrame.User.IsGuest() && saslHandler.RequiresPassport;
```

`GetGenderString` feeds `GetProfileString` → `Irc5_ToString`/`Irc7_ToString`/`ToString` (IRC8), so `G` is emitted across all four protocol variants.

## Tests

107/107 passing (75 baseline + 32 new): `PropPuidTests.cs` (`EvaluateGet` classes incl. gate-first ordering and flag↔reply consistency), `PropSendPropsTests.cs` (`819`-only / `908`-only / `818`+`819` wire counts, multi-prop `908` suppression, determinism), `UserProfileTests.cs` (`G`/`GO`, `R`/`MY`/`FY`/`PX`, guest-overrides-`HasPuid`, determinism).

A client follow-up (gate the irc7_chat View Profile button on the `G` flag) is a separate task.

Closes #184